### PR TITLE
ln: minor improvements

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package apd
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// runBenches benchmarks a given function on random decimals on combinations of
+// three parameters:
+//
+//   precision:    desired output precision
+//   inScale:      the scale of the input decimal: the absolute value will be between
+//                 10^inScale and 10^(inScale+1)
+//   inNumDigits:  number of digits in the input decimal; if negative the number
+//                 will be negative and the number of digits are the absolute value.
+func runBenches(
+	b *testing.B, precision, inScale, inNumDigits []int, fn func(*testing.B, *Context, *Decimal),
+) {
+	for _, p := range precision {
+		for _, s := range inScale {
+			for _, d := range inNumDigits {
+				numDigits := d
+				negative := false
+				if d < 0 {
+					numDigits = -d
+					negative = true
+				}
+
+				// Generate some random numbers with the given number of digits.
+				nums := make([]Decimal, 20)
+				for i := range nums {
+					var buf bytes.Buffer
+					if negative {
+						buf.WriteByte('-')
+					}
+					buf.WriteByte('1' + byte(rand.Intn(9)))
+					for j := 1; j < numDigits; j++ {
+						buf.WriteByte('0' + byte(rand.Intn(10)))
+					}
+					if _, err := nums[i].SetString(buf.String()); err != nil {
+						b.Fatal(err)
+					}
+					nums[i].SetExponent(int32(s - d))
+				}
+				b.Run(
+					fmt.Sprintf("P%d/S%d/D%d", p, s, d),
+					func(b *testing.B) {
+						ctx := BaseContext.WithPrecision(uint32(p))
+						for i := 0; i <= b.N; i++ {
+							fn(b, ctx, &nums[i%len(nums)])
+						}
+					},
+				)
+			}
+		}
+	}
+}
+
+func BenchmarkLn(b *testing.B) {
+	precision := []int{2, 10, 100}
+	scale := []int{-100, -10, -2, 2, 10, 100}
+	digits := []int{2, 10, 100}
+	runBenches(
+		b, precision, scale, digits,
+		func(b *testing.B, ctx *Context, x *Decimal) {
+			if _, err := ctx.Ln(&Decimal{}, x); err != nil {
+				b.Fatal(err)
+			}
+		},
+	)
+}

--- a/context.go
+++ b/context.go
@@ -526,7 +526,7 @@ func (c *Context) Ln(d, x *Decimal) (Condition, error) {
 	m := new(Decimal)
 	for z.Cmp(decimalHalf) < 0 {
 		ed.Sub(m, m, decimalOne)
-		ed.Mul(z, z, decimalTwo)
+		ed.Add(z, z, z)
 	}
 	for z.Cmp(decimalOne) > 0 {
 		ed.Add(m, m, decimalOne)
@@ -556,15 +556,20 @@ func (c *Context) Ln(d, x *Decimal) (Condition, error) {
 
 		// tmp2 = exp(a_n)
 		ed.Exp(tmp2, tmp1)
+
 		// tmp3 = exp(a_n) - z
 		ed.Sub(tmp3, tmp2, z)
+
+		// tmp3 = 2 * (exp(a_n) - z)
+		ed.Add(tmp3, tmp3, tmp3)
+
 		// tmp4 = exp(a_n) + z
 		ed.Add(tmp4, tmp2, z)
-		// tmp2 = (exp(a_n) - z) / (exp(a_n) + z)
-		ed.Quo(tmp2, tmp3, tmp4)
+
 		// tmp2 = 2 * (exp(a_n) - z) / (exp(a_n) + z)
-		ed.Mul(tmp2, tmp2, decimalTwo)
-		// tmp2 = a_n+1 = a_n - 2 * (exp(a_n) - z) / (exp(a_n) + z)
+		ed.Quo(tmp2, tmp3, tmp4)
+
+		// tmp2 = a_(n+1) = a_n - 2 * (exp(a_n) - z) / (exp(a_n) + z)
 		ed.Sub(tmp2, tmp1, tmp2)
 
 		if done, err := loop.done(tmp2); err != nil {


### PR DESCRIPTION
Hi Matt,

The Ln code looks good to me! I just have this suggested minor improvement to replace `Mul` by `decimalTwo` with an `Add` (should be a bit faster). I couldn't run the benchmark to verify if we see an improvement though.

I think we could stop the loop when the delta (tmp2) becomes small enough (less than `10^-c.Precision` or so). We would also optimize out the `Sub` in `loop.done()` since we already know the delta. I will look at that.

By the way, I don't quite understand the logic in `loop.done()`; we "stall" when `l.delta.Cmp(l.prevDelta) == 0`? Why? I would expect in most iterative algorithms the delta to keep decreasing.. So we should stop when it becomes 0 or smaller than a certain value no?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/7)
<!-- Reviewable:end -->
