### PR TITLE
better loop termination criteria

### DIFF
--- a/context.go
+++ b/context.go
@@ -457,7 +457,7 @@ func (c *Context) Cbrt(d, x *Decimal) (Condition, error) {
 	z0.Set(z)
 
 	// Loop until convergence.
-	for loop := nc.newLoop("cbrt", z, 1); ; {
+	for loop := nc.newLoop("cbrt", z, c.Precision, 1); false; {
 		// z = (2.0 * z0 +  x / (z0 * z0) ) / 3.0;
 		z.Set(z0)
 		ed.Mul(z, z, z0)
@@ -553,7 +553,9 @@ func (c *Context) Ln(d, x *Decimal) (Condition, error) {
 	ed.Mul(tmp1, tmp1, tmp2)
 
 	// Use Halley's Iteration.
-	for loop := nc.newLoop("ln", x, 1); ; {
+	// We use a bit more precision than the context asks for in newLoop because
+	// this is not the final result.
+	for loop := nc.newLoop("ln", x, c.Precision+1, 1); ; {
 		// tmp1 = a_n (either from initial estimate or last iteration)
 
 		// tmp2 = exp(a_n)

--- a/loop.go
+++ b/loop.go
@@ -14,32 +14,35 @@ import (
 
 type loop struct {
 	c             *Context
-	name          string   // The name of the function we are evaluating.
-	i             uint64   // Loop count.
+	name          string // The name of the function we are evaluating.
+	i             uint64 // Loop count.
+	precision     int32
 	maxIterations uint64   // When to give up.
-	stallCount    int      // Iterations since |delta| changed more than threshold.
 	arg           *Decimal // original argument to function; only used for diagnostic.
 	prevZ         *Decimal // Result from the previous iteration.
 	delta         *Decimal // |Change| from previous iteration.
-	prevDelta     *Decimal // The maximum |delta| to be considered a stall.
 }
 
 const digitsToBitsRatio = math.Ln10 / math.Ln2
 
-// newLoop returns a new loop checker. The arguments are the name
-// of the function being evaluated, the argument to the function, and
-// the maximum number of iterations to perform before giving up.
-// The last number in terms of iterations per digit, so the caller can
-// ignore the precision setting.
-func (c *Context) newLoop(name string, x *Decimal, itersPerDigit int) *loop {
+// newLoop returns a new loop checker. Arguments:
+// 	 - name: name of the function being calculated (for error messages)
+// 	 - arg: argument to the function (for error messages)
+// 	 - precision: desired precision; the loop ends when consecutive estimates
+// 	              differ less than the desired precision. Note that typically
+// 	              the inner computations in an iteration need higher precision,
+// 	              so this is normally lower than the precision in the context.
+// 	 - maxItersPerDigit: after this many iterations per digit of precision, the
+// 	                     loop ends in error.
+func (c *Context) newLoop(name string, arg *Decimal, precision uint32, maxItersPerDigit int) *loop {
 	return &loop{
 		c:             c,
 		name:          name,
-		arg:           new(Decimal).Set(x),
-		maxIterations: 10 + uint64(itersPerDigit*int(c.Precision)),
+		arg:           new(Decimal).Set(arg),
+		precision:     int32(precision),
+		maxIterations: 10 + uint64(maxItersPerDigit*int(precision)),
 		prevZ:         new(Decimal),
 		delta:         new(Decimal),
-		prevDelta:     new(Decimal),
 	}
 }
 
@@ -47,34 +50,38 @@ func (c *Context) newLoop(name string, x *Decimal, itersPerDigit int) *loop {
 // after the maximum number of iterations, it returns an error.
 func (l *loop) done(z *Decimal) (bool, error) {
 	l.c.Sub(l.delta, l.prevZ, z)
-	if l.delta.Sign() == 0 {
+	sign := l.delta.Sign()
+	if sign == 0 {
 		return true, nil
 	}
-	if l.delta.Sign() < 0 {
+	if sign < 0 {
 		// Convergence can oscillate when the calculation is nearly
 		// done and we're running out of bits. This stops that.
 		// See next comment.
 		l.delta.Neg(l.delta)
 	}
-	if l.delta.Cmp(l.prevDelta) == 0 {
-		// In freaky cases (like e**3) we can hit the same large positive
-		// and then  large negative value (4.5, -4.5) so we count a few times
-		// to see that it really has stalled. Avoids having to do hard math,
-		// but it means we may iterate a few extra times. Usually, though,
-		// iteration is stopped by the zero check above, so this is fine.
-		l.stallCount++
-		if l.stallCount > 3 {
-			// Convergence has stopped.
-			return true, nil
-		}
-	} else {
-		l.stallCount = 0
+
+	// We stop if the delta is smaller than a change of 1 in the
+	// (l.precision)-th digit of z. Examples:
+	//
+	//   p   = 4
+	//   z   = 12345.678 = 12345678 * 10^-3
+	//   eps =    10.000 = 10^(-4+8-3)
+	//
+	//   p   = 3
+	//   z   = 0.001234 = 1234 * 10^-6
+	//   eps = 0.00001  = 10^(-3+4-6)
+	eps := Decimal{Coeff: *bigOne, Exponent: -l.precision + int32(z.NumDigits()) + z.Exponent}
+	if l.delta.Cmp(&eps) <= 0 {
+		return true, nil
 	}
 	l.i++
 	if l.i == l.maxIterations {
-		return false, errors.Errorf("%s %s: did not converge after %d iterations; prev,last result %s,%s delta %s", l.name, l.arg.String(), l.maxIterations, z, l.prevZ, l.delta)
+		return false, errors.Errorf(
+			"%s %s: did not converge after %d iterations; prev,last result %s,%s delta %s precision: %d",
+			l.name, l.arg.String(), l.maxIterations, z, l.prevZ, l.delta, l.precision,
+		)
 	}
-	l.prevDelta.Set(l.delta)
 	l.prevZ.Set(z)
 	return false, nil
 }


### PR DESCRIPTION
Note: only the last commit is the subject of this PR (the others are in a separate one).

The loop termination criteria was very funky. I have fixed it in the repo we
got this code from: robpike/ivy#32

Applying a similar (but better) fix here. When doing iterations, we want the
"inner" computations to be done at a higher precision. But the iteration should
stop when the estimate reaches the desired "outer" precision. This desired
precision is now passed to newLoop.

An alternative would be to use the precision in the context. This would mean
that iterations would use an "inner" context and an "outer" (loop) context. I
figured this could be more confusing/error-prone.

```
Ln/P2/S-100/D2-24       973µs ± 1%   645µs ± 2%  -33.76%  (p=0.029 n=4+4)
Ln/P2/S-10/D2-24        472µs ± 2%   321µs ± 2%  -32.04%  (p=0.029 n=4+4)
Ln/P2/S-2/D2-24         616µs ± 2%   315µs ± 1%  -48.93%  (p=0.029 n=4+4)
Ln/P2/S2/D2-24          492µs ± 2%   312µs ± 0%  -36.63%  (p=0.029 n=4+4)
Ln/P2/S10/D2-24         563µs ± 1%   359µs ± 1%  -36.27%  (p=0.029 n=4+4)
Ln/P2/S100/D2-24        824µs ± 1%   667µs ± 1%  -19.02%  (p=0.029 n=4+4)
Ln/P10/S-100/D2-24      927µs ± 1%   886µs ± 1%   -4.42%  (p=0.029 n=4+4)
Ln/P10/S-100/D10-24    1.06ms ± 1%  0.88ms ± 2%  -17.20%  (p=0.029 n=4+4)
Ln/P10/S-10/D2-24       621µs ± 1%   591µs ± 1%   -4.97%  (p=0.029 n=4+4)
Ln/P10/S-10/D10-24      727µs ± 1%   590µs ± 2%  -18.80%  (p=0.029 n=4+4)
Ln/P10/S-2/D2-24        632µs ± 0%   543µs ± 0%  -14.12%  (p=0.029 n=4+4)
Ln/P10/S-2/D10-24       671µs ± 1%   591µs ± 2%  -11.87%  (p=0.029 n=4+4)
Ln/P10/S2/D2-24         672µs ± 2%   521µs ± 0%  -22.48%  (p=0.029 n=4+4)
Ln/P10/S2/D10-24        625µs ± 2%   563µs ± 2%   -9.91%  (p=0.029 n=4+4)
Ln/P10/S10/D2-24        609µs ± 1%   561µs ± 2%   -7.98%  (p=0.029 n=4+4)
Ln/P10/S10/D10-24       612µs ± 1%   594µs ± 4%     ~     (p=0.200 n=4+4)
Ln/P10/S100/D2-24      1.07ms ± 1%  0.92ms ± 1%  -14.19%  (p=0.029 n=4+4)
Ln/P10/S100/D10-24      987µs ± 0%   924µs ± 3%   -6.47%  (p=0.029 n=4+4)
Ln/P100/S-100/D2-24    41.2ms ± 2%  37.3ms ± 3%   -9.58%  (p=0.029 n=4+4)
Ln/P100/S-100/D10-24   35.7ms ± 1%  35.6ms ± 1%     ~     (p=0.686 n=4+4)
Ln/P100/S-100/D100-24  37.1ms ± 3%  36.9ms ± 1%     ~     (p=0.886 n=4+4)
Ln/P100/S-10/D2-24     33.8ms ± 1%  33.1ms ± 1%     ~     (p=0.057 n=4+4)
Ln/P100/S-10/D10-24    36.8ms ± 1%  34.1ms ± 1%   -7.34%  (p=0.029 n=4+4)
Ln/P100/S-10/D100-24   35.6ms ± 0%  33.2ms ± 0%   -6.76%  (p=0.029 n=4+4)
Ln/P100/S-2/D2-24      35.4ms ± 1%  33.3ms ± 1%   -5.76%  (p=0.029 n=4+4)
Ln/P100/S-2/D10-24     35.1ms ± 2%  33.6ms ± 1%   -4.33%  (p=0.029 n=4+4)
Ln/P100/S-2/D100-24    36.7ms ± 0%  35.4ms ± 2%   -3.62%  (p=0.029 n=4+4)
Ln/P100/S2/D2-24       41.9ms ± 0%  30.6ms ± 0%  -26.89%  (p=0.029 n=4+4)
Ln/P100/S2/D10-24      44.1ms ± 1%  34.8ms ± 1%  -20.99%  (p=0.029 n=4+4)
Ln/P100/S2/D100-24     36.7ms ± 1%  35.3ms ± 2%   -3.84%  (p=0.029 n=4+4)
Ln/P100/S10/D2-24      35.6ms ± 1%  34.3ms ± 2%   -3.47%  (p=0.029 n=4+4)
Ln/P100/S10/D10-24     33.5ms ± 1%  31.9ms ± 1%   -4.99%  (p=0.029 n=4+4)
Ln/P100/S10/D100-24    35.4ms ± 1%  32.8ms ± 1%   -7.57%  (p=0.029 n=4+4)
Ln/P100/S100/D2-24     36.8ms ± 1%  35.0ms ± 1%   -4.84%  (p=0.029 n=4+4)
Ln/P100/S100/D10-24    37.9ms ± 1%  34.3ms ± 1%   -9.53%  (p=0.029 n=4+4)
Ln/P100/S100/D100-24   36.0ms ± 1%  34.3ms ± 0%   -4.87%  (p=0.029 n=4+4)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/10)
<!-- Reviewable:end -->
