### PR TITLE
use a table for 10^x calculations

### DIFF
--- a/context.go
+++ b/context.go
@@ -940,8 +940,7 @@ func (c *Context) quantize(d, v, e *Decimal) Condition {
 		if diff < MinExponent {
 			return SystemUnderflow | Underflow
 		}
-		y := big.NewInt(-int64(diff))
-		e := new(big.Int).Exp(bigTen, y, nil)
+		e := tableExp10(-int64(diff), nil)
 		d.Coeff.Mul(&d.Coeff, e)
 	} else if diff > 0 {
 		p := int32(d.NumDigits()) - diff
@@ -1013,12 +1012,11 @@ func (c *Context) Reduce(d, x *Decimal) (Condition, error) {
 	return c.Round(d, d)
 }
 
-// exp10 returns x, 1*10^x. An error is returned if x is too large.
+// exp10 returns x, 10^x. An error is returned if x is too large.
 func exp10(x int64) (f, exp *big.Int, err error) {
 	if x > MaxExponent || x < MinExponent {
 		return nil, nil, errors.New(errExponentOutOfRangeStr)
 	}
 	f = big.NewInt(x)
-	// TODO(mjibson): use a table here.
-	return f, new(big.Int).Exp(bigTen, f, nil), nil
+	return f, tableExp10(x, f), nil
 }

--- a/decimal.go
+++ b/decimal.go
@@ -339,9 +339,8 @@ func upscale(a, b *Decimal) (*big.Int, *big.Int, int32, error) {
 	if s > MaxExponent {
 		return nil, nil, 0, errors.New(errExponentOutOfRangeStr)
 	}
-	x := big.NewInt(s)
-	// TODO(mjibson): use a table here.
-	e := new(big.Int).Exp(bigTen, x, nil)
+	x := new(big.Int)
+	e := tableExp10(s, x)
 	x.Mul(&a.Coeff, e)
 	y := &b.Coeff
 	if swapped {
@@ -397,10 +396,9 @@ func (d *Decimal) Cmp(x *Decimal) int {
 	if diff < 0 {
 		diff = -diff
 	}
-	y := big.NewInt(diff)
-	// TODO(mjibson): use a table here.
-	e := new(big.Int).Exp(bigTen, y, nil)
-	db := new(big.Int).Set(&d.Coeff)
+	db := new(big.Int)
+	e := tableExp10(diff, db)
+	db.Set(&d.Coeff)
 	xb := new(big.Int).Set(&x.Coeff)
 	if d.Exponent > x.Exponent {
 		db.Mul(db, e)
@@ -442,8 +440,7 @@ func (d *Decimal) Modf(integ, frac *Decimal) {
 		return
 	}
 
-	y := big.NewInt(exp)
-	e := new(big.Int).Exp(bigTen, y, nil)
+	e := tableExp10(exp, nil)
 	integ.Coeff.QuoRem(&d.Coeff, e, &frac.Coeff)
 	integ.Exponent = 0
 	frac.Exponent = d.Exponent

--- a/round.go
+++ b/round.go
@@ -70,8 +70,8 @@ func (r Rounder) Round(c *Context, d, x *Decimal) Condition {
 			return SystemUnderflow | Underflow
 		}
 		res |= Rounded
-		y := big.NewInt(diff)
-		e := new(big.Int).Exp(bigTen, y, nil)
+		y := new(big.Int)
+		e := tableExp10(diff, y)
 		m := new(big.Int)
 		y.QuoRem(&d.Coeff, e, m)
 		if m.Sign() != 0 {

--- a/table.go
+++ b/table.go
@@ -85,3 +85,39 @@ func NumDigits(b *big.Int) int64 {
 	}
 	return n
 }
+
+// powerTenTableSize is the magnitude of the maximum power of 10 exponent that
+// is stored in the pow10LookupTable. For instance, if the powerTenTableSize
+// if 3, then the lookup table will store power of 10 values from 10^0 to
+// 10^3 inclusive.
+const powerTenTableSize = 64
+
+var pow10LookupTable [powerTenTableSize + 1]big.Int
+
+func init() {
+	tmpInt := new(big.Int)
+	for i := int64(0); i <= powerTenTableSize; i++ {
+		setBigWithPow(&pow10LookupTable[i], tmpInt, i)
+	}
+}
+
+func setBigWithPow(bi *big.Int, tmpInt *big.Int, pow int64) {
+	if tmpInt == nil {
+		tmpInt = new(big.Int)
+	}
+	bi.Exp(bigTen, tmpInt.SetInt64(pow), nil)
+}
+
+// tableExp10 returns 10^x for x >= 0, looked up from a table when possible. If
+// f is not nil, it will be set to x. The returned value must not be mutated.
+func tableExp10(x int64, f *big.Int) *big.Int {
+	if x <= powerTenTableSize {
+		if f != nil {
+			f.SetInt64(int64(x))
+		}
+		return &pow10LookupTable[x]
+	}
+	b := new(big.Int)
+	setBigWithPow(b, f, x)
+	return b
+}

--- a/table_test.go
+++ b/table_test.go
@@ -92,3 +92,34 @@ func TestDigitsLookupTable(t *testing.T) {
 		}
 	}
 }
+
+func TestTableExp10(t *testing.T) {
+	tests := []struct {
+		pow int64
+		str string
+	}{
+		{
+			pow: 0,
+			str: "1",
+		},
+		{
+			pow: 1,
+			str: "10",
+		},
+		{
+			pow: 5,
+			str: "100000",
+		},
+		{
+			pow: powerTenTableSize + 1,
+			str: "100000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+
+	for i, test := range tests {
+		d := tableExp10(test.pow, nil)
+		if s := d.String(); s != test.str {
+			t.Errorf("%d: expected PowerOfTenDec(%d) to give %s, got %s", i, test.pow, test.str, s)
+		}
+	}
+}


### PR DESCRIPTION
```
name                 old time/op  new time/op  delta
GDA/abs-12           91.5µs ± 1%  98.9µs ±21%     ~     (p=0.690 n=5+5)
GDA/add-12           6.35ms ± 9%  4.77ms ±11%  -24.85%  (p=0.008 n=5+5)
GDA/base-12          1.05ms ± 7%  1.03ms ± 7%     ~     (p=0.151 n=5+5)
GDA/compare-12        552µs ± 4%   515µs ± 1%   -6.70%  (p=0.008 n=5+5)
GDA/divide-12        1.64ms ±11%  1.45ms ± 9%  -11.78%  (p=0.032 n=5+5)
GDA/divideint-12      254µs ± 8%   184µs ± 7%  -27.36%  (p=0.008 n=5+5)
GDA/exp-12            177ms ±13%   107ms ±12%  -39.57%  (p=0.008 n=5+5)
GDA/ln-12             405ms ±24%   353ms ±41%     ~     (p=0.098 n=13+15)
GDA/log10-12          561ms ±16%   302ms ± 3%  -46.16%  (p=0.008 n=5+5)
GDA/minus-12          142µs ±21%    97µs ± 1%  -31.64%  (p=0.008 n=5+5)
GDA/multiply-12      1.16ms ± 7%  0.73ms ± 2%  -37.06%  (p=0.008 n=5+5)
GDA/plus-12           403µs ±13%   265µs ± 2%  -34.15%  (p=0.008 n=5+5)
GDA/power-12          945ms ±19%   601ms ± 3%  -36.45%  (p=0.008 n=5+5)
GDA/quantize-12      1.48ms ±17%  0.82ms ±10%  -44.72%  (p=0.008 n=5+5)
GDA/randoms-12        268ms ± 8%   179ms ± 4%  -33.02%  (p=0.008 n=5+5)
GDA/reduce-12         246µs ± 5%   204µs ± 1%  -17.07%  (p=0.008 n=5+5)
GDA/remainder-12      926µs ±13%   498µs ± 1%  -46.22%  (p=0.008 n=5+5)
GDA/rounding-12      72.0ms ±18%  42.6ms ± 2%  -40.75%  (p=0.008 n=5+5)
GDA/squareroot-12     158ms ±14%   103ms ± 5%  -34.38%  (p=0.008 n=5+5)
GDA/subtract-12      2.28ms ±10%  1.23ms ± 2%  -46.13%  (p=0.008 n=5+5)
GDA/tointegral-12     423µs ±14%   236µs ± 2%  -44.32%  (p=0.008 n=5+5)
GDA/tointegralx-12    421µs ±16%   243µs ± 2%  -42.35%  (p=0.008 n=5+5)
GDA/cuberoot-apd-12  5.43ms ± 5%  4.55ms ± 1%  -16.18%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/17)
<!-- Reviewable:end -->
