### PR TITLE
Update travis to use point releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.7
+  - 1.8
 
 script: go test


### PR DESCRIPTION
Before it was stuck to go1.8rc1 and 1.7.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/18)
<!-- Reviewable:end -->
