### PR TITLE
NumDigits: minor speedups in lookup table logic

### DIFF
--- a/table_test.go
+++ b/table_test.go
@@ -22,6 +22,48 @@ import (
 	"testing"
 )
 
+func BenchmarkNumDigitsLookup(b *testing.B) {
+	b.StopTimer()
+	runTest := func(start string, c byte) {
+		buf := bytes.NewBufferString(start)
+		for i := 1; i < digitsTableSize; i++ {
+			buf.WriteByte(c)
+			d, _, _ := NewFromString(buf.String())
+
+			b.StartTimer()
+			d.NumDigits()
+			b.StopTimer()
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		runTest("", '9')
+		runTest("1", '0')
+		runTest("-", '9')
+		runTest("-1", '0')
+	}
+}
+
+func BenchmarkNumDigitsFull(b *testing.B) {
+	b.StopTimer()
+	runTest := func(start string, c byte) {
+		buf := bytes.NewBufferString(start)
+		for i := 1; i < 1000; i++ {
+			buf.WriteByte(c)
+			d, _, _ := NewFromString(buf.String())
+
+			b.StartTimer()
+			d.NumDigits()
+			b.StopTimer()
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		runTest("", '9')
+		runTest("1", '0')
+		runTest("-", '9')
+		runTest("-1", '0')
+	}
+}
+
 func TestNumDigits(t *testing.T) {
 	runTest := func(start string, c byte) {
 		buf := bytes.NewBufferString(start)
@@ -112,7 +154,7 @@ func TestTableExp10(t *testing.T) {
 		},
 		{
 			pow: powerTenTableSize + 1,
-			str: "100000000000000000000000000000000000000000000000000000000000000000",
+			str: "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 		},
 	}
 


### PR DESCRIPTION
Also don't take Abs when not needed.

```
name                old time/op    new time/op    delta
NumDigitsLookup-12     775µs ±14%     381µs ± 3%  -50.80%  (p=0.008 n=5+5)
NumDigitsFull-12      13.0ms ±19%    12.8ms ±11%     ~     (p=1.000 n=5+5)

name                old alloc/op   new alloc/op   delta
NumDigitsLookup-12     115kB ± 0%      22kB ± 0%     ~     (p=0.079 n=4+5)
NumDigitsFull-12      4.49MB ± 0%    3.91MB ± 0%  -12.88%  (p=0.008 n=5+5)

name                old allocs/op  new allocs/op  delta
NumDigitsLookup-12     2.14k ± 0%     0.42k ± 0%  -80.43%  (p=0.008 n=5+5)
NumDigitsFull-12       34.6k ± 0%     31.1k ± 0%  -10.06%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/21)
<!-- Reviewable:end -->
