### PR TITLE
simplify returns for exp10 funcs

### DIFF
--- a/context.go
+++ b/context.go
@@ -789,7 +789,7 @@ func (c *Context) Exp(d, x *Decimal) (Condition, error) {
 	}
 
 	// sum ** k
-	_, ki, err := exp10(int64(t))
+	ki, err := exp10(int64(t))
 	if err != nil {
 		return 0, errors.Wrap(err, "ki")
 	}
@@ -1013,10 +1013,9 @@ func (c *Context) Reduce(d, x *Decimal) (Condition, error) {
 }
 
 // exp10 returns x, 10^x. An error is returned if x is too large.
-func exp10(x int64) (f, exp *big.Int, err error) {
+func exp10(x int64) (exp *big.Int, err error) {
 	if x > MaxExponent || x < MinExponent {
-		return nil, nil, errors.New(errExponentOutOfRangeStr)
+		return nil, errors.New(errExponentOutOfRangeStr)
 	}
-	f = big.NewInt(x)
-	return f, tableExp10(x, f), nil
+	return tableExp10(x, nil), nil
 }

--- a/table.go
+++ b/table.go
@@ -119,16 +119,14 @@ func setBigWithPow(bi *big.Int, tmpInt *big.Int, pow int64) {
 	bi.Exp(bigTen, tmpInt.SetInt64(pow), nil)
 }
 
-// tableExp10 returns 10^x for x >= 0, looked up from a table when possible. If
-// f is not nil, it will be set to x. The returned value must not be mutated.
-func tableExp10(x int64, f *big.Int) *big.Int {
+// tableExp10 returns 10^x for x >= 0, looked up from a table when
+// possible. This returned value must not be mutated. tmp is used as an
+// intermediate variable, but may be nil.
+func tableExp10(x int64, tmp *big.Int) *big.Int {
 	if x <= powerTenTableSize {
-		if f != nil {
-			f.SetInt64(int64(x))
-		}
 		return &pow10LookupTable[x]
 	}
 	b := new(big.Int)
-	setBigWithPow(b, f, x)
+	setBigWithPow(b, tmp, x)
 	return b
 }


### PR DESCRIPTION
Nothing used the guaranteed setting of the 2nd param, remove.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/23)
<!-- Reviewable:end -->
