### PR TITLE
round: fix rounding bug found by quantize

### DIFF
--- a/context.go
+++ b/context.go
@@ -228,7 +228,7 @@ func (c *Context) Quo(d, x, y *Decimal) (Condition, error) {
 			half := dividend.Cmp(divisor)
 			rounding := c.rounding()
 			if rounding(&quo.Coeff, half) {
-				roundAddOne(&quo.Coeff, &diff)
+				roundAddOne(&quo.Coeff, &diff, 1 /* positive */)
 			}
 		}
 	}
@@ -951,16 +951,9 @@ func (c *Context) quantize(d, v, e *Decimal) Condition {
 			}
 		} else {
 			nc := c.WithPrecision(uint32(p))
-			neg := d.Sign() < 0
 			// Avoid the c.Precision == 0 check.
 			res = nc.Rounding.Round(nc, d, d)
 			offset = d.Exponent - diff
-			// TODO(mjibson): There may be a bug in roundAddOne or roundFunc that
-			// unexpectedly removes a negative sign when converting from -9 to -10. This
-			// check is needed until it is fixed.
-			if neg && d.Sign() > 0 {
-				d.Coeff.Neg(&d.Coeff)
-			}
 		}
 	}
 	d.Exponent = e.Exponent + offset

--- a/round.go
+++ b/round.go
@@ -50,10 +50,11 @@ type Rounder func(result *big.Int, half int) bool
 func (r Rounder) Round(c *Context, d, x *Decimal) Condition {
 	d.Set(x)
 	nd := x.NumDigits()
+	xs := x.Sign()
 	var res Condition
 
 	// adj is the adjusted exponent: exponent + clength - 1
-	if adj := int64(x.Exponent) + nd - 1; x.Sign() != 0 && adj < int64(c.MinExponent) {
+	if adj := int64(x.Exponent) + nd - 1; xs != 0 && adj < int64(c.MinExponent) {
 		// Subnormal is defined before rounding.
 		res |= Subnormal
 		// setExponent here to prevent double-rounded subnormals.
@@ -79,7 +80,7 @@ func (r Rounder) Round(c *Context, d, x *Decimal) Condition {
 			m.Abs(m)
 			discard := NewWithBigInt(m, int32(-diff))
 			if r(y, discard.Cmp(decimalHalf)) {
-				roundAddOne(y, &diff)
+				roundAddOne(y, &diff, xs)
 			}
 		}
 		d.Coeff = *y
@@ -90,10 +91,10 @@ func (r Rounder) Round(c *Context, d, x *Decimal) Condition {
 	return res
 }
 
-// roundAddOne adds 1 to abs(b).
-func roundAddOne(b *big.Int, diff *int64) {
+// roundAddOne adds 1 to abs(b). sign is the sign of the rounded number.
+func roundAddOne(b *big.Int, diff *int64, sign int) {
 	nd := NumDigits(b)
-	if b.Sign() >= 0 {
+	if sign >= 0 {
 		b.Add(b, bigOne)
 	} else {
 		b.Sub(b, bigOne)


### PR DESCRIPTION
When rounding from -0.9 to -1.0, the coefficient would be first set
to 0, and then 1 added to it. Since 0 isn't negative, 1 was added
instead of subtracted as it should have been. The fix is to record
the sign before rounding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/27)
<!-- Reviewable:end -->
