### PR TITLE
pow: correctly compute exactness

### DIFF
--- a/context.go
+++ b/context.go
@@ -842,36 +842,20 @@ func (c *Context) integerPower(d, x *Decimal, y *big.Int) (Condition, error) {
 	}
 
 	if neg {
-		e := z.Exponent
-		if e < 0 {
-			e = -e
-		}
-		qc := c.WithPrecision((uint32(z.NumDigits()) + uint32(e)) * 2)
-		ed.Ctx = qc
 		ed.Quo(z, decimalOne, z)
-		ed.Ctx = c
 	}
 	return ed.Flags, ed.Err()
 }
 
 // Pow sets d = x**y.
 func (c *Context) Pow(d, x, y *Decimal) (Condition, error) {
-	// x ** 1 == x
-	if y.Cmp(decimalOne) == 0 {
-		return c.Round(d, x)
-	}
-	// 1 ** x == 1
-	if x.Cmp(decimalOne) == 0 {
-		return c.Round(d, x)
-	}
-
 	// Check if y is of type int.
 	tmp := new(Decimal)
 	if _, err := c.Abs(tmp, y); err != nil {
 		return 0, errors.Wrap(err, "Abs")
 	}
 	integ, frac := new(Decimal), new(Decimal)
-	tmp.Modf(integ, frac)
+	y.Modf(integ, frac)
 	yIsInt := frac.Sign() == 0
 
 	xs := x.Sign()
@@ -910,6 +894,19 @@ func (c *Context) Pow(d, x, y *Decimal) (Condition, error) {
 	p += 4
 
 	nc := BaseContext.WithPrecision(p)
+
+	if yIsInt {
+		// If integ.Exponent > 0, we need to add trailing 0s to integ.Coeff.
+		res := c.quantize(integ, integ, 0)
+		nres, err := nc.integerPower(d, x, &integ.Coeff)
+		res |= nres
+		if err != nil {
+			return res, err
+		}
+		res |= c.round(d, d)
+		return c.goError(res)
+	}
+
 	ed := MakeErrDecimal(nc)
 
 	ed.Abs(tmp, x)
@@ -925,9 +922,7 @@ func (c *Context) Pow(d, x, y *Decimal) (Condition, error) {
 		return ed.Flags, err
 	}
 	res := c.round(d, tmp)
-	if !yIsInt {
-		res |= Inexact
-	}
+	res |= Inexact
 	return c.goError(res)
 }
 

--- a/gda_test.go
+++ b/gda_test.go
@@ -557,7 +557,7 @@ func gdaTest(t *testing.T, path string, tcs []TestCase) {
 				rcond &= ^Rounded
 
 				switch tc.Operation {
-				case "log10", "power":
+				case "log10":
 					// TODO(mjibson): Under certain conditions these are exact, but we don't
 					// correctly mark them. Ignore these flags for now.
 					// squareroot sometimes marks things exact when GDA says they should be


### PR DESCRIPTION
Power calculations of x**y where y is an integer will now correctly
be flagged as exact when possible. This avoids lots of work and is
thus much faster for these operations.

Remove some unneeded precision changing in integerPower. It
was leftover from the inf code which did bad things with 1/x
calculations. This was causing some overflow problems that shouldn't
have been present.

This change reduces `go test` time from 2.5s to 0.9s.

```
name          old time/op  new time/op  delta
GDA/power-12   666ms ±16%   387ms ± 6%  -41.86%  (p=0.008 n=5+5)
```

---

First commit is from another PR, but has a fix this needs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/30)
<!-- Reviewable:end -->
