### PR TITLE
Remove unused block in sqrt

### DIFF
--- a/context.go
+++ b/context.go
@@ -531,25 +531,6 @@ func (c *Context) Sqrt(d, x *Decimal) (Condition, error) {
 		// approx = 0.5 * (approx + f / approx)
 		ed.Mul(approx, tmp, decimalHalf)
 	}
-	nc.Precision = workp
-	dp := int32(c.Precision)
-	approxsubhalf := new(Decimal)
-	ed.Sub(approxsubhalf, approx, New(5, -1-dp))
-	nc.Rounding = RoundUp
-	ed.Mul(approxsubhalf, approxsubhalf, approxsubhalf)
-	if approxsubhalf.Cmp(f) > 0 {
-		// TODO(mjibson): this branch is never taken in tests, why? Can it be removed?
-		ed.Sub(approx, approx, New(1, -dp))
-	} else {
-		approxaddhalf := new(Decimal)
-		ed.Add(approxaddhalf, approx, New(5, -1-dp))
-		nc.Rounding = RoundDown
-		ed.Mul(approxaddhalf, approxaddhalf, approxaddhalf)
-		if approxaddhalf.Cmp(f) < 0 {
-			ed.Add(approx, approx, New(1, -dp))
-		}
-	}
-
 	if err := ed.Err(); err != nil {
 		return 0, err
 	}

--- a/context.go
+++ b/context.go
@@ -531,6 +531,16 @@ func (c *Context) Sqrt(d, x *Decimal) (Condition, error) {
 		// approx = 0.5 * (approx + f / approx)
 		ed.Mul(approx, tmp, decimalHalf)
 	}
+	
+	// At this point the paper says: "approx is now within 1 ulp of the properly
+	// rounded square root off; to ensure proper rounding, compare squares of
+	// (approx - l/2 ulp) and (approx + l/2 ulp) with f." We originally implemented
+	// the proceeding algorithm from the paper. However none of the tests take
+	// any of the branches that modify approx. Our best guess as to why is that
+	// since we use workp + 5 instead of the + 2 as described in the paper,
+	// we are more accurate than this section needed to account for. Thus,
+	// we have removed the block from this implementation.
+	
 	if err := ed.Err(); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Neither of the branches that modified approx here were taken in any
tests, so the tests still pass without them. Even though this is
described in the paper, I think it is safe to remove.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/43)
<!-- Reviewable:end -->
