### PR TITLE
return number of zeros removed during reduce

### DIFF
--- a/context.go
+++ b/context.go
@@ -1266,16 +1266,17 @@ func (c *Context) Floor(d, x *Decimal) (Condition, error) {
 	return 0, nil
 }
 
-// Reduce sets d to x with all trailing zeros removed.
-func (c *Context) Reduce(d, x *Decimal) (Condition, error) {
+// Reduce sets d to x with all trailing zeros removed and returns the number
+// of zeros removed.
+func (c *Context) Reduce(d, x *Decimal) (int, Condition, error) {
 	if set, res, err := c.setIfNaN(d, x); set {
-		return res, err
+		return 0, res, err
 	}
 	neg := x.Negative
-	d.Reduce(x)
+	_, n := d.Reduce(x)
 	d.Negative = neg
 	res, err := c.Round(d, d)
-	return res, err
+	return n, res, err
 }
 
 // exp10 returns x, 10^x. An error is returned if x is too large.

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -542,3 +542,40 @@ func TestIsZero(t *testing.T) {
 		})
 	}
 }
+
+func TestReduce(t *testing.T) {
+	tests := map[string]int{
+		"-0":        0,
+		"0":         0,
+		"0.0":       0,
+		"00":        0,
+		"0.00":      0,
+		"-01000":    3,
+		"01000":     3,
+		"-1":        0,
+		"1":         0,
+		"-10.000E4": 4,
+		"10.000E4":  4,
+		"-10.00":    3,
+		"10.00":     3,
+		"-10":       1,
+		"10":        1,
+		"-143200000000000000000000000000000000000000000000000000000000": 56,
+		"143200000000000000000000000000000000000000000000000000000000":  56,
+		"Inf": 0,
+		"NaN": 0,
+	}
+
+	for s, n := range tests {
+		t.Run(s, func(t *testing.T) {
+			d, _, err := NewFromString(s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, got := d.Reduce(d)
+			if n != got {
+				t.Fatalf("got %v, expected %v", got, n)
+			}
+		})
+	}
+}

--- a/error.go
+++ b/error.go
@@ -145,9 +145,16 @@ func (e *ErrDecimal) QuoInteger(d, x, y *Decimal) *Decimal {
 	return e.op3(d, x, y, e.Ctx.QuoInteger)
 }
 
-// Reduce performs e.Ctx.Reduce(d, x) and returns d.
-func (e *ErrDecimal) Reduce(d, x *Decimal) *Decimal {
-	return e.op2(d, x, e.Ctx.Reduce)
+// Reduce performs e.Ctx.Reduce(d, x) and returns the number of zeros removed
+// and d.
+func (e *ErrDecimal) Reduce(d, x *Decimal) (int, *Decimal) {
+	if e.Err() != nil {
+		return 0, d
+	}
+	n, res, err := e.Ctx.Reduce(d, x)
+	e.Flags |= res
+	e.err = err
+	return n, d
 }
 
 // Rem performs e.Ctx.Rem(d, x, y) and returns d.

--- a/gda_test.go
+++ b/gda_test.go
@@ -268,7 +268,7 @@ func (tc TestCase) Run(c *Context, done chan error, d, x, y *Decimal) (res Condi
 	case "quantize":
 		res, err = c.Quantize(d, x, y.Exponent)
 	case "reduce":
-		res, err = c.Reduce(d, x)
+		_, res, err = c.Reduce(d, x)
 	case "remainder":
 		res, err = c.Rem(d, x, y)
 	case "squareroot":


### PR DESCRIPTION
This is useful to determine if any zero truncation occurred without running a CmpTotal.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/46)
<!-- Reviewable:end -->
