### PR TITLE
reduce the size of the Decimal struct

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -33,8 +33,8 @@ import (
 type Decimal struct {
 	Form     Form
 	Negative bool
-	Coeff    big.Int
 	Exponent int32
+	Coeff    big.Int
 }
 
 type Form int

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"unsafe"
 )
 
 var (
@@ -582,5 +583,14 @@ func TestReduce(t *testing.T) {
 				t.Fatalf("got %v, expected %v", got, n)
 			}
 		})
+	}
+}
+
+// TestSizeof is meant to catch changes that unexpectedly increase
+// the size of the Decimal struct.
+func TestSizeof(t *testing.T) {
+	var d Decimal
+	if s := unsafe.Sizeof(d); s != 48 {
+		t.Errorf("sizeof(Decimal) changed: %d", s)
 	}
 }


### PR DESCRIPTION
Moving the exponent next to the flag so they share the same word. This decreases
the size of `Decimal` by 8 bytes (to 48). Adding a test that needs to be updated
if the size changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/52)
<!-- Reviewable:end -->
