### PR TITLE
reduce the size of the Context struct

### DIFF
--- a/context.go
+++ b/context.go
@@ -29,9 +29,6 @@ type Context struct {
 	// effectively the total number of digits (before and after the decimal
 	// point).
 	Precision uint32
-	// Rounding specifies the Rounder to use during rounding. RoundHalfUp is used if
-	// empty or not present in Roundings.
-	Rounding string
 	// MaxExponent specifies the largest effective exponent. The
 	// effective exponent is the value of the Decimal in scientific notation. That
 	// is, for 10e2, the effective exponent is 3 (1.0e3). Zero (0) is not a special
@@ -43,6 +40,9 @@ type Context struct {
 	// Traps are the conditions which will trigger an error result if the
 	// corresponding Flag condition occurred.
 	Traps Condition
+	// Rounding specifies the Rounder to use during rounding. RoundHalfUp is used if
+	// empty or not present in Roundings.
+	Rounding string
 }
 
 const (

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -593,4 +593,8 @@ func TestSizeof(t *testing.T) {
 	if s := unsafe.Sizeof(d); s != 48 {
 		t.Errorf("sizeof(Decimal) changed: %d", s)
 	}
+	var c Context
+	if s := unsafe.Sizeof(c); s != 32 {
+		t.Errorf("sizeof(Context) changed: %d", s)
+	}
 }


### PR DESCRIPTION
Similar to the previous commit, reduces Context from 40 to 32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/apd/53)
<!-- Reviewable:end -->
