### PR TITLE
Implement json.Unmarshaler and json.Marshaler interfaces

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -15,8 +15,8 @@
 package apd
 
 import (
+	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"math"
 	"math/big"
 	"strconv"
@@ -774,16 +774,14 @@ func (d *Decimal) Scan(src interface{}) error {
 	}
 }
 
+var jsonNull = []byte("null")
+
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (d *Decimal) UnmarshalJSON(b []byte) error {
-	var n json.Number
-	if err := json.Unmarshal(b, &n); err != nil {
-		return err
+	if bytes.Compare(b, jsonNull) == 0 {
+		return nil
 	}
-	if _, _, err := d.SetString(n.String()); err != nil {
-		return err
-	}
-	return nil
+	return d.UnmarshalText(b)
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
@@ -794,7 +792,7 @@ func (d *Decimal) UnmarshalText(b []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (d *Decimal) MarshalJSON() ([]byte, error) {
-	return []byte(d.String()), nil
+	return d.MarshalText()
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.

--- a/decimal.go
+++ b/decimal.go
@@ -15,7 +15,6 @@
 package apd
 
 import (
-	"bytes"
 	"database/sql/driver"
 	"math"
 	"math/big"
@@ -774,11 +773,11 @@ func (d *Decimal) Scan(src interface{}) error {
 	}
 }
 
-var jsonNull = []byte("null")
+const jsonNull string = "null"
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (d *Decimal) UnmarshalJSON(b []byte) error {
-	if bytes.Compare(b, jsonNull) == 0 {
+	if string(b) == jsonNull {
 		return nil
 	}
 	return d.UnmarshalText(b)

--- a/decimal.go
+++ b/decimal.go
@@ -16,6 +16,7 @@ package apd
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"math"
 	"math/big"
 	"strconv"
@@ -773,10 +774,27 @@ func (d *Decimal) Scan(src interface{}) error {
 	}
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *Decimal) UnmarshalJSON(b []byte) error {
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	if _, _, err := d.SetString(n.String()); err != nil {
+		return err
+	}
+	return nil
+}
+
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (d *Decimal) UnmarshalText(b []byte) error {
 	_, _, err := d.SetString(string(b))
 	return err
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (d *Decimal) MarshalJSON() ([]byte, error) {
+	return []byte(d.String()), nil
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.


### PR DESCRIPTION
Implementing the `encoding.TextUnmarshaler` and `encoding.TextMarshaler` interfaces aren't sufficient for decoding/encoding JSON numbers since JSON numbers aren't strings.

See the docs:
* https://golang.org/pkg/encoding/json/#Unmarshal
  > Otherwise, if the value implements encoding.TextUnmarshaler and the input is a JSON quoted string, Unmarshal calls that value's UnmarshalText method with the unquoted form of the string. 
* https://golang.org/pkg/encoding/json/#Marshal
  > If no MarshalJSON method is present but the value implements encoding.TextMarshaler instead, Marshal calls its MarshalText method and encodes the result as a JSON string.

In other words:
  - `UnmarshalText()` will support unmarshaling Decimals in JSON objects like `{"decimal": "1.1"}`
  - `UnmarshalJSON()` will support unmarshling Decimals in JSON ojbects like `{"decimal": 1.1}`

Since most JSON objects use JSON numbers instead of strings, we need to implement the `json.Unmarshaler` interface.