### PR TITLE
Prevent decimal.Neg from returning -0

### DIFF
--- a/context.go
+++ b/context.go
@@ -182,12 +182,7 @@ func (c *Context) Neg(d, x *Decimal) (Condition, error) {
 	if set, res, err := c.setIfNaN(d, x); set {
 		return res, err
 	}
-	if x.IsZero() {
-		d.Set(x)
-		d.Negative = false
-	} else {
-		d.Neg(x)
-	}
+	d.Neg(x)
 	return c.Round(d, d)
 }
 

--- a/decimal.go
+++ b/decimal.go
@@ -684,7 +684,11 @@ func (d *Decimal) Modf(integ, frac *Decimal) {
 // Neg sets d to -x and returns d.
 func (d *Decimal) Neg(x *Decimal) *Decimal {
 	d.Set(x)
-	d.Negative = !d.Negative
+	if d.IsZero() {
+		d.Negative = false
+	} else {
+		d.Negative = !d.Negative
+	}
 	return d
 }
 

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -695,6 +695,30 @@ func TestIsZero(t *testing.T) {
 	}
 }
 
+func TestNeg(t *testing.T) {
+	tests := map[string]string{
+		"0":          "0",
+		"-0":         "0",
+		"-0.000":     "0.000",
+		"-00.000100": "0.000100",
+	}
+
+	for tc, expect := range tests {
+		t.Run(tc, func(t *testing.T) {
+			d, _, err := NewFromString(tc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var z Decimal
+			z.Neg(d)
+			s := z.String()
+			if s != expect {
+				t.Fatalf("expected %s, got %s", expect, s)
+			}
+		})
+	}
+}
+
 func TestReduce(t *testing.T) {
 	tests := map[string]int{
 		"-0":        0,


### PR DESCRIPTION
This behavior is explicitly tested for in GDA, but the implementation was
only in the Context struct. Move it to the Decimal struct so that any
users of Decimal will benefit from this, as it is standard across int,
float, and decimal specifications.