### PR TITLE
apd: update example to use apd/v2

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,7 @@ package apd_test
 import (
 	"fmt"
 
-	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/apd/v2"
 )
 
 // ExampleOverflow demonstrates how to detect or error on overflow.


### PR DESCRIPTION
Import paths need to include a "/v2" in them if referencing a version greater then v1.