### PR TITLE
apd: tune performance by inlining function calls and manually unrolling loops

### DIFF
--- a/bigint.go
+++ b/bigint.go
@@ -214,10 +214,19 @@ func (z *BigInt) innerAsUint() (val uint, neg bool, ok bool) {
 		// The value is not stored inline.
 		return 0, false, false
 	}
-	for i := 1; i < len(z._inline); i++ {
-		if z._inline[i] != 0 {
+	if inlineWords == 2 {
+		// Manually unrolled loop for current inlineWords setting.
+		if z._inline[1] != 0 {
 			// The value can not fit in a uint.
 			return 0, false, false
+		}
+	} else {
+		// Fallback for other values of inlineWords.
+		for i := 1; i < len(z._inline); i++ {
+			if z._inline[i] != 0 {
+				// The value can not fit in a uint.
+				return 0, false, false
+			}
 		}
 	}
 
@@ -235,8 +244,14 @@ func (z *BigInt) innerAsUint() (val uint, neg bool, ok bool) {
 func (z *BigInt) updateInnerFromUint(val uint, neg bool) {
 	// Set the inline value, making sure to clear out all other words.
 	z._inline[0] = big.Word(val)
-	for i := 1; i < len(z._inline); i++ {
-		z._inline[i] = 0
+	if inlineWords == 2 {
+		// Manually unrolled loop for current inlineWords setting.
+		z._inline[1] = 0
+	} else {
+		// Fallback for other values of inlineWords.
+		for i := 1; i < len(z._inline); i++ {
+			z._inline[i] = 0
+		}
 	}
 
 	// Set or unset the negative sentinel.

--- a/context.go
+++ b/context.go
@@ -79,6 +79,7 @@ func (c *Context) WithPrecision(p uint32) *Context {
 }
 
 // goError converts flags into an error based on c.Traps.
+//gcassert:inline
 func (c *Context) goError(flags Condition) (Condition, error) {
 	return flags.GoError(c.Traps)
 }
@@ -156,7 +157,8 @@ func (c *Context) add(d, x, y *Decimal, subtract bool) (Condition, error) {
 	}
 	d.Exponent = s
 	d.Form = Finite
-	return c.Round(d, d)
+	res := c.round(d, d)
+	return c.goError(res)
 }
 
 // Add sets d to the sum x+y.
@@ -175,7 +177,8 @@ func (c *Context) Abs(d, x *Decimal) (Condition, error) {
 		return res, err
 	}
 	d.Abs(x)
-	return c.Round(d, d)
+	res := c.round(d, d)
+	return c.goError(res)
 }
 
 // Neg sets d to -x.
@@ -184,7 +187,8 @@ func (c *Context) Neg(d, x *Decimal) (Condition, error) {
 		return res, err
 	}
 	d.Neg(x)
-	return c.Round(d, d)
+	res := c.round(d, d)
+	return c.goError(res)
 }
 
 // Mul sets d to the product x*y.
@@ -552,7 +556,8 @@ func (c *Context) Sqrt(d, x *Decimal) (Condition, error) {
 	nc.Precision = c.Precision
 	nc.Rounding = RoundHalfEven
 	d.Reduce(d) // Remove trailing zeros.
-	return nc.Round(d, d)
+	res := nc.round(d, d)
+	return nc.goError(res)
 }
 
 // Cbrt sets d to the cube root of x.
@@ -631,7 +636,8 @@ func (c *Context) Cbrt(d, x *Decimal) (Condition, error) {
 	}
 
 	z0.Set(x)
-	res, err := c.Round(d, &z)
+	res := c.round(d, &z)
+	res, err := c.goError(res)
 	d.Negative = neg
 
 	// Set z = d^3 to check for exactness.
@@ -1278,7 +1284,8 @@ func (c *Context) Reduce(d, x *Decimal) (int, Condition, error) {
 	neg := x.Negative
 	_, n := d.Reduce(x)
 	d.Negative = neg
-	res, err := c.Round(d, d)
+	res := c.round(d, d)
+	res, err := c.goError(res)
 	return n, res, err
 }
 

--- a/context.go
+++ b/context.go
@@ -89,25 +89,31 @@ func (c *Context) etiny() int32 {
 	return c.MinExponent - int32(c.Precision) + 1
 }
 
-// setIfNaN sets d to the first NaNSignaling, or otherwise first NaN, of
-// vals. d' is unchanged if vals contains no NaNs. True is returned if d
-// was set to a NaN.
-func (c *Context) setIfNaN(d *Decimal, vals ...*Decimal) (bool, Condition, error) {
+// shouldSetAsNaN determines whether setAsNaN should be called, given
+// the provided values, where x is required and y is optional. It is
+// split from setAsNaN to permit inlining of this function.
+//gcassert:inline
+func (c *Context) shouldSetAsNaN(x, y *Decimal) bool {
+	return x.Form == NaNSignaling || x.Form == NaN ||
+		(y != nil && (y.Form == NaNSignaling || y.Form == NaN))
+}
+
+// setAsNaN sets d to the first NaNSignaling, or otherwise first NaN, of
+// x and y. x is required, y is optional. Expects one of the two inputs
+// to be NaN.
+func (c *Context) setAsNaN(d *Decimal, x, y *Decimal) (Condition, error) {
 	var nan *Decimal
-Loop:
-	for _, v := range vals {
-		switch v.Form {
-		case NaNSignaling:
-			nan = v
-			break Loop
-		case NaN:
-			if nan == nil {
-				nan = v
-			}
-		}
-	}
-	if nan == nil {
-		return false, 0, nil
+	// Per the method contract, NaNSignaling takes precedence over NaN.
+	if x.Form == NaNSignaling {
+		nan = x
+	} else if y != nil && y.Form == NaNSignaling {
+		nan = y
+	} else if x.Form == NaN {
+		nan = x
+	} else if y != nil && y.Form == NaN {
+		nan = y
+	} else {
+		return 0, errors.Errorf("no NaN value found; was shouldSetAsNaN called?")
 	}
 	d.Set(nan)
 	var res Condition
@@ -116,12 +122,12 @@ Loop:
 		d.Form = NaN
 	}
 	_, err := c.goError(res)
-	return true, res, err
+	return res, err
 }
 
 func (c *Context) add(d, x, y *Decimal, subtract bool) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x, y); set {
-		return res, err
+	if c.shouldSetAsNaN(x, y) {
+		return c.setAsNaN(d, x, y)
 	}
 	xn := x.Negative
 	yn := y.Negative != subtract
@@ -173,8 +179,8 @@ func (c *Context) Sub(d, x, y *Decimal) (Condition, error) {
 
 // Abs sets d to |x| (the absolute value of x).
 func (c *Context) Abs(d, x *Decimal) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
-		return res, err
+	if c.shouldSetAsNaN(x, nil) {
+		return c.setAsNaN(d, x, nil)
 	}
 	d.Abs(x)
 	res := c.round(d, d)
@@ -183,8 +189,8 @@ func (c *Context) Abs(d, x *Decimal) (Condition, error) {
 
 // Neg sets d to -x.
 func (c *Context) Neg(d, x *Decimal) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
-		return res, err
+	if c.shouldSetAsNaN(x, nil) {
+		return c.setAsNaN(d, x, nil)
 	}
 	d.Neg(x)
 	res := c.round(d, d)
@@ -193,8 +199,8 @@ func (c *Context) Neg(d, x *Decimal) (Condition, error) {
 
 // Mul sets d to the product x*y.
 func (c *Context) Mul(d, x, y *Decimal) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x, y); set {
-		return res, err
+	if c.shouldSetAsNaN(x, y) {
+		return c.setAsNaN(d, x, y)
 	}
 	// The sign of the result is the exclusive or of the signs of the operands.
 	neg := x.Negative != y.Negative
@@ -217,9 +223,11 @@ func (c *Context) Mul(d, x, y *Decimal) (Condition, error) {
 }
 
 func (c *Context) quoSpecials(d, x, y *Decimal, canClamp bool) (bool, Condition, error) {
-	if set, res, err := c.setIfNaN(d, x, y); set {
+	if c.shouldSetAsNaN(x, y) {
+		res, err := c.setAsNaN(d, x, y)
 		return true, res, err
 	}
+
 	// The sign of the result is the exclusive or of the signs of the operands.
 	neg := x.Negative != y.Negative
 	if xi, yi := x.Form == Infinite, y.Form == Infinite; xi || yi {
@@ -400,8 +408,8 @@ func (c *Context) QuoInteger(d, x, y *Decimal) (Condition, error) {
 // Rem sets d to the remainder part of the quotient x/y. If
 // the integer part cannot fit in d.Precision digits, an error is returned.
 func (c *Context) Rem(d, x, y *Decimal) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x, y); set {
-		return res, err
+	if c.shouldSetAsNaN(x, y) {
+		return c.setAsNaN(d, x, y)
 	}
 
 	if x.Form != Finite {
@@ -443,8 +451,9 @@ func (c *Context) Rem(d, x, y *Decimal) (Condition, error) {
 }
 
 func (c *Context) rootSpecials(d, x *Decimal, factor int32) (bool, Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
-		return set, res, err
+	if c.shouldSetAsNaN(x, nil) {
+		res, err := c.setAsNaN(d, x, nil)
+		return true, res, err
 	}
 	if x.Form == Infinite {
 		if x.Negative {
@@ -656,8 +665,9 @@ func (c *Context) Cbrt(d, x *Decimal) (Condition, error) {
 }
 
 func (c *Context) logSpecials(d, x *Decimal) (bool, Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
-		return set, res, err
+	if c.shouldSetAsNaN(x, nil) {
+		res, err := c.setAsNaN(d, x, nil)
+		return true, res, err
 	}
 	if x.Sign() < 0 {
 		d.Set(decimalNaN)
@@ -879,8 +889,8 @@ func (c *Context) Exp(d, x *Decimal) (Condition, error) {
 	// See: Variable Precision Exponential Function, T. E. Hull and A. Abrham, ACM
 	// Transactions on Mathematical Software, Vol 12 #2, pp79-91, ACM, June 1986.
 
-	if set, res, err := c.setIfNaN(d, x); set {
-		return res, err
+	if c.shouldSetAsNaN(x, nil) {
+		return c.setAsNaN(d, x, nil)
 	}
 	if x.Form == Infinite {
 		if x.Negative {
@@ -1043,8 +1053,8 @@ func (c *Context) integerPower(d, x *Decimal, y *BigInt) (Condition, error) {
 
 // Pow sets d = x**y.
 func (c *Context) Pow(d, x, y *Decimal) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x, y); set {
-		return res, err
+	if c.shouldSetAsNaN(x, y) {
+		return c.setAsNaN(d, x, y)
 	}
 
 	var integ, frac Decimal
@@ -1151,8 +1161,8 @@ func (c *Context) Pow(d, x, y *Decimal) (Condition, error) {
 // Quantize adjusts and rounds x as necessary so it is represented with
 // exponent exp and stores the result in d.
 func (c *Context) Quantize(d, x *Decimal, exp int32) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
-		return res, err
+	if c.shouldSetAsNaN(x, nil) {
+		return c.setAsNaN(d, x, nil)
 	}
 	if x.Form == Infinite || exp < c.etiny() {
 		d.Set(decimalNaN)
@@ -1225,8 +1235,9 @@ func (c *Context) toIntegral(d, x *Decimal) Condition {
 }
 
 func (c *Context) toIntegralSpecials(d, x *Decimal) (bool, Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
-		return set, res, err
+	if c.shouldSetAsNaN(x, nil) {
+		res, err := c.setAsNaN(d, x, nil)
+		return true, res, err
 	}
 	if x.Form != Finite {
 		d.Set(x)
@@ -1278,7 +1289,8 @@ func (c *Context) Floor(d, x *Decimal) (Condition, error) {
 // Reduce sets d to x with all trailing zeros removed and returns the number
 // of zeros removed.
 func (c *Context) Reduce(d, x *Decimal) (int, Condition, error) {
-	if set, res, err := c.setIfNaN(d, x); set {
+	if c.shouldSetAsNaN(x, nil) {
+		res, err := c.setAsNaN(d, x, nil)
 		return 0, res, err
 	}
 	neg := x.Negative

--- a/context.go
+++ b/context.go
@@ -211,7 +211,7 @@ func (c *Context) Mul(d, x, y *Decimal) (Condition, error) {
 	d.Coeff.Mul(&x.Coeff, &y.Coeff)
 	d.Negative = neg
 	d.Form = Finite
-	res := d.setExponent(c, 0, int64(x.Exponent), int64(y.Exponent))
+	res := d.setExponent(c, unknownNumDigits, 0, int64(x.Exponent), int64(y.Exponent))
 	res |= c.round(d, d)
 	return c.goError(res)
 }
@@ -364,7 +364,7 @@ func (c *Context) Quo(d, x, y *Decimal) (Condition, error) {
 	// The exponent of the result is computed by subtracting the sum of the
 	// original exponent of the divisor and the value of adjust at the end of
 	// the coefficient calculation from the original exponent of the dividend.
-	res |= quo.setExponent(c, res, int64(x.Exponent), int64(-y.Exponent), -adjust, diff)
+	res |= quo.setExponent(c, unknownNumDigits, res, int64(x.Exponent), int64(-y.Exponent), -adjust, diff)
 	quo.Negative = neg
 	d.Set(&quo)
 	return c.goError(res)

--- a/decimal.go
+++ b/decimal.go
@@ -197,14 +197,21 @@ func (c *Context) SetString(d *Decimal, s string) (*Decimal, Condition, error) {
 }
 
 // Set sets d's fields to the values of x and returns d.
+//gcassert:inline
 func (d *Decimal) Set(x *Decimal) *Decimal {
 	if d == x {
 		return d
 	}
-	d.Negative = x.Negative
-	d.Coeff.Set(&x.Coeff)
-	d.Exponent = x.Exponent
+	return d.setSlow(x)
+}
+
+// setSlow is split from Set to allow the aliasing fast-path to be
+// inlined in callers.
+func (d *Decimal) setSlow(x *Decimal) *Decimal {
 	d.Form = x.Form
+	d.Negative = x.Negative
+	d.Exponent = x.Exponent
+	d.Coeff.Set(&x.Coeff)
 	return d
 }
 

--- a/decimal.go
+++ b/decimal.go
@@ -499,8 +499,8 @@ func (d *Decimal) cmpOrder() int {
 // This comparison respects the normal rules of special values (like NaN),
 // and does not compare them.
 func (c *Context) Cmp(d, x, y *Decimal) (Condition, error) {
-	if set, res, err := c.setIfNaN(d, x, y); set {
-		return res, err
+	if c.shouldSetAsNaN(x, y) {
+		return c.setAsNaN(d, x, y)
 	}
 	v := x.Cmp(y)
 	d.SetInt64(int64(v))

--- a/round.go
+++ b/round.go
@@ -24,7 +24,7 @@ func (c *Context) Round(d, x *Decimal) (Condition, error) {
 func (c *Context) round(d, x *Decimal) Condition {
 	if c.Precision == 0 {
 		d.Set(x)
-		return d.setExponent(c, 0, int64(d.Exponent))
+		return d.setExponent(c, unknownNumDigits, 0, int64(d.Exponent))
 	}
 	res := c.Rounding.Round(c, d, x)
 	return res
@@ -74,7 +74,7 @@ func (r Rounder) Round(c *Context, d, x *Decimal) Condition {
 		// Subnormal is defined before rounding.
 		res |= Subnormal
 		// setExponent here to prevent double-rounded subnormals.
-		res |= d.setExponent(c, res, int64(d.Exponent))
+		res |= d.setExponent(c, nd, res, int64(d.Exponent))
 		return res
 	}
 
@@ -100,10 +100,12 @@ func (r Rounder) Round(c *Context, d, x *Decimal) Condition {
 			}
 		}
 		d.Coeff.Set(&y)
+		// The coefficient changed, so recompute num digits in setExponent.
+		nd = unknownNumDigits
 	} else {
 		diff = 0
 	}
-	res |= d.setExponent(c, res, int64(d.Exponent), diff)
+	res |= d.setExponent(c, nd, res, int64(d.Exponent), diff)
 	return res
 }
 


### PR DESCRIPTION
This PR contains a series of follow-on micro-optimizations that build upon the changes in https://github.com/cockroachdb/apd/pull/106.

The individual changes here focus primarily on inlining function calls on the hot paths and on manually unrolling loops where possible. For the first form of optimization, it uses `gcassert` to detect regressions. I'm still hoping to add `gcassert` to CI, but that is currently blocked on https://github.com/jordanlewis/gcassert/pull/3.

Impact on benchmark suite:
```
name                 old time/op    new time/op    delta
GDA/squareroot-10      16.0ms ± 1%    12.6ms ± 0%  -21.26%  (p=0.000 n=8+9)
GDA/abs-10             6.14µs ± 1%    4.85µs ± 0%  -21.04%  (p=0.000 n=10+8)
GDA/powersqrt-10        246ms ± 0%     195ms ± 1%  -20.49%  (p=0.000 n=9+9)
GDA/reduce-10          14.0µs ± 0%    11.3µs ± 1%  -19.00%  (p=0.000 n=8+9)
GDA/minus-10           7.83µs ± 0%    6.57µs ± 1%  -16.10%  (p=0.000 n=8+10)
GDA/rounding-10         308µs ± 0%     261µs ± 1%  -15.20%  (p=0.000 n=8+10)
GDA/remainder-10       32.8µs ± 1%    28.7µs ± 1%  -12.47%  (p=0.000 n=8+10)
GDA/divide-10           268µs ± 0%     237µs ± 1%  -11.57%  (p=0.000 n=8+10)
GDA/quantize-10        81.2µs ± 1%    72.8µs ± 1%  -10.29%  (p=0.000 n=9+10)
GDA/divideint-10       15.9µs ± 1%    14.3µs ± 0%   -9.92%  (p=0.000 n=8+8)
GDA/subtract-10        95.7µs ± 1%    86.7µs ± 1%   -9.48%  (p=0.000 n=8+9)
GDA/compare-10         29.1µs ± 1%    26.6µs ± 1%   -8.87%  (p=0.000 n=10+9)
GDA/multiply-10        56.2µs ± 1%    52.2µs ± 1%   -7.24%  (p=0.000 n=9+9)
GDA/cuberoot-apd-10    1.95ms ± 0%    1.82ms ± 0%   -6.92%  (p=0.000 n=8+9)
GDA/randoms-10         1.88ms ± 1%    1.77ms ± 0%   -5.91%  (p=0.000 n=9+9)
GDA/tointegralx-10     18.4µs ± 1%    17.4µs ± 1%   -5.57%  (p=0.000 n=9+10)
GDA/ln-10              85.3ms ± 0%    80.8ms ± 0%   -5.30%  (p=0.000 n=9+9)
GDA/tointegral-10      18.0µs ± 1%    17.1µs ± 0%   -5.08%  (p=0.000 n=9+10)
GDA/log10-10            110ms ± 0%     104ms ± 0%   -4.91%  (p=0.000 n=8+8)
GDA/plus-10            36.5µs ± 1%    34.7µs ± 0%   -4.86%  (p=0.000 n=9+9)
GDA/add-10              603µs ± 0%     576µs ± 1%   -4.49%  (p=0.000 n=9+9)
GDA/power-10            227ms ± 0%     217ms ± 0%   -4.46%  (p=0.000 n=9+9)
GDA/exp-10              125ms ± 0%     121ms ± 1%   -3.12%  (p=0.000 n=8+10)
GDA/comparetotal-10    25.6µs ± 2%    24.9µs ± 2%   -2.64%  (p=0.000 n=10+10)
GDA/base-10             117µs ± 1%     117µs ± 1%     ~     (p=0.326 n=10+8)
```

The benchmark suites are valuable to give good coverage over a diverse set of operations. However, because each "op" is actually a few thousand different arithmetic operations over varying sized values, they don't give much intuition about the absolute cost of these operations. Additionally, because they try to exercise edge cases, the average operation in these tests skews expensive.

Here's the impact of this change on a single basic addition operation (`add '1.23456789'  '1.00000000' -> '2.23456789'`):
```
name        old time/op    new time/op    delta
GDA/add-10    80.9ns ± 1%    73.6ns ± 1%  -9.10%  (p=0.000 n=10+10)
```