### PR TITLE
apd: add apd.BigInt / math/big.Int interop methods

### DIFF
--- a/bigint.go
+++ b/bigint.go
@@ -937,3 +937,22 @@ func (z *BigInt) Xor(x, y *BigInt) *BigInt {
 	z.updateInner(zi)
 	return z
 }
+
+///////////////////////////////////////////////////////////////////////////////
+//                     apd.BigInt / math/big.Int interop                     //
+///////////////////////////////////////////////////////////////////////////////
+
+// MathBigInt returns the math/big.Int representation of z.
+func (z *BigInt) MathBigInt() *big.Int {
+	var tmp1 big.Int
+	return z.inner(&tmp1)
+}
+
+// SetMathBigInt sets z to x and returns z.
+func (z *BigInt) SetMathBigInt(x *big.Int) *BigInt {
+	var tmp1 big.Int
+	zi := z.inner(&tmp1)
+	zi.Set(x)
+	z.updateInner(zi)
+	return z
+}

--- a/bigint_test.go
+++ b/bigint_test.go
@@ -751,6 +751,32 @@ func TestBigIntMatchesMathBigInt(t *testing.T) {
 	})
 }
 
+// TestBigIntMathBigIntRoundTrip uses testing/quick to verify that the
+// apd.BigInt / math/big.Int interoperation methods each round-trip.
+func TestBigIntMathBigIntRoundTrip(t *testing.T) {
+	t.Run("apd->math->apd", func(t *testing.T) {
+		base := func(z number) string {
+			return z.toApd(t).String()
+		}
+		roundtrip := func(z number) string {
+			bi := z.toApd(t).MathBigInt()
+			return new(BigInt).SetMathBigInt(bi).String()
+		}
+		require(t, quick.CheckEqual(base, roundtrip, nil))
+	})
+
+	t.Run("math->apd->math", func(t *testing.T) {
+		base := func(z number) string {
+			return z.toMath(t).String()
+		}
+		roundtrip := func(z number) string {
+			bi := new(BigInt).SetMathBigInt(z.toMath(t))
+			return bi.MathBigInt().String()
+		}
+		require(t, quick.CheckEqual(base, roundtrip, nil))
+	})
+}
+
 // number is a quick.Generator for large integer numbers.
 type number string
 


### PR DESCRIPTION
This commit adds a `MathBigInt` and a `SetMathBigInt` method to `BigInt`.

These allow the type to more easily interoperate with `math/big.Int`.