### PR TITLE
apd: don't strip trailing zeros in Quo and Sqrt

### DIFF
--- a/context.go
+++ b/context.go
@@ -371,7 +371,6 @@ func (c *Context) Quo(d, x, y *Decimal) (Condition, error) {
 	}
 
 	res |= d.setExponent(c, nd, res, shift, -adjCoeffs, -adjExp10)
-	d.Reduce(d) // remove trailing zeros
 	return c.goError(res)
 }
 
@@ -561,7 +560,6 @@ func (c *Context) Sqrt(d, x *Decimal) (Condition, error) {
 	d.Exponent += int32(e / 2)
 	nc.Precision = c.Precision
 	nc.Rounding = RoundHalfEven
-	d.Reduce(d) // remove trailing zeros
 	res := nc.round(d, d)
 	return nc.goError(res)
 }

--- a/decimal.go
+++ b/decimal.go
@@ -716,7 +716,7 @@ func (d *Decimal) Reduce(x *Decimal) (*Decimal, int) {
 	d.Set(x)
 
 	// Use a uint64 for the division if possible.
-	if d.Coeff.BitLen() <= 64 {
+	if d.Coeff.IsUint64() {
 		i := d.Coeff.Uint64()
 		for i >= 10000 && i%10000 == 0 {
 			i /= 10000

--- a/example_test.go
+++ b/example_test.go
@@ -56,9 +56,10 @@ func ExampleContext_inexact() {
 			return
 		}
 	}
-	// Output: d:       9, inexact: false, err: <nil>
-	// d:       3, inexact: false, err: <nil>
-	// d:       1, inexact: false, err: <nil>
+	// Output:
+	// d:  9.0000, inexact: false, err: <nil>
+	// d:  3.0000, inexact: false, err: <nil>
+	// d:  1.0000, inexact: false, err: <nil>
 	// d: 0.33333, inexact:  true, err: <nil>
 }
 

--- a/gda_test.go
+++ b/gda_test.go
@@ -711,10 +711,6 @@ func (tc TestCase) PrintIgnore() {
 }
 
 var GDAignore = map[string]bool{
-	// GDA says decNumber should skip these
-	"powx4302": true,
-	"powx4303": true,
-
 	// Invalid context
 	"expx901":  true,
 	"expx902":  true,
@@ -775,21 +771,6 @@ var GDAignore = map[string]bool{
 
 	// TODO(mjibson): fix tests below
 
-	// log10(x) with large exponents, overflows
-	"logx0020": true,
-	"logx1146": true,
-	"logx1147": true,
-	"logx1156": true,
-	"logx1157": true,
-	"logx1176": true,
-	"logx1177": true,
-
-	// log10(x) where x is 1.0 +/- some tiny epsilon. Our results are close but
-	// differ in the last places.
-	"logx1304": true,
-	"logx1309": true,
-	"logx1310": true,
-
 	// overflows to infinity
 	"powx4125": true,
 	"powx4145": true,
@@ -819,90 +800,13 @@ var GDAignore = map[string]bool{
 	"addx61618": true,
 
 	// extreme input range, but should work
-	"lnx0902":  true,
-	"sqtx8137": true,
-	"sqtx8139": true,
-	"sqtx8145": true,
-	"sqtx8147": true,
-	"sqtx8149": true,
-	"sqtx8150": true,
-	"sqtx8151": true,
-	"sqtx8158": true,
-	"sqtx8165": true,
-	"sqtx8168": true,
-	"sqtx8174": true,
-	"sqtx8175": true,
-	"sqtx8179": true,
-	"sqtx8182": true,
-	"sqtx8185": true,
-	"sqtx8186": true,
-	"sqtx8195": true,
-	"sqtx8196": true,
-	"sqtx8197": true,
-	"sqtx8199": true,
-	"sqtx8204": true,
-	"sqtx8212": true,
-	"sqtx8213": true,
-	"sqtx8214": true,
-	"sqtx8218": true,
-	"sqtx8219": true,
-	"sqtx8323": true,
-	"sqtx8324": true,
-	"sqtx8331": true,
-	"sqtx8626": true,
-	"sqtx8627": true,
-	"sqtx8628": true,
-	"sqtx8631": true,
-	"sqtx8632": true,
-	"sqtx8633": true,
-	"sqtx8634": true,
 	"sqtx8636": true,
-	"sqtx8637": true,
-	"sqtx8639": true,
-	"sqtx8640": true,
-	"sqtx8641": true,
 	"sqtx8644": true,
-	"sqtx8645": true,
 	"sqtx8646": true,
 	"sqtx8647": true,
 	"sqtx8648": true,
-	"sqtx8649": true,
 	"sqtx8650": true,
 	"sqtx8651": true,
-	"sqtx8652": true,
-	"sqtx8654": true,
-
-	// tricky cases of underflow subnormals
-	"sqtx8700": true,
-	"sqtx8701": true,
-	"sqtx8702": true,
-	"sqtx8703": true,
-	"sqtx8704": true,
-	"sqtx8705": true,
-	"sqtx8706": true,
-	"sqtx8707": true,
-	"sqtx8708": true,
-	"sqtx8709": true,
-	"sqtx8710": true,
-	"sqtx8711": true,
-	"sqtx8712": true,
-	"sqtx8713": true,
-	"sqtx8714": true,
-	"sqtx8715": true,
-	"sqtx8716": true,
-	"sqtx8717": true,
-	"sqtx8718": true,
-	"sqtx8719": true,
-	"sqtx8720": true,
-	"sqtx8721": true,
-	"sqtx8722": true,
-	"sqtx8723": true,
-	"sqtx8724": true,
-	"sqtx8725": true,
-	"sqtx8726": true,
-	"sqtx8727": true,
-	"sqtx8728": true,
-	"sqtx8729": true,
 }
 
 var GDAignoreFlags = map[string]bool{
@@ -915,9 +819,4 @@ var GDAignoreFlags = map[string]bool{
 	"sqtx9039": true,
 	"sqtx9040": true,
 	"sqtx9045": true,
-
-	// missing underflow, subnormal
-	"expx048": true,
-	"expx756": true,
-	"expx757": true,
 }


### PR DESCRIPTION
First 4 commits from #114. Please ignore all but the last.

Before this commit, `Quo` and `Sqrt` were stripping trailing zeros from
their result. This was different from the behavior in PostgreSQL, where
these operations retain all trailing zeros based on the precision of
the computation:

In PostgreSQL:
```sql
nathan=# select d, v from dec;
    d    |  v
---------+-----
      10 |   4
 10.0000 | 4.0
(2 rows)

nathan=# select d/v, scale(d/v), trim_scale(d/v) from dec;
      ?column?      | scale | trim_scale
--------------------+-------+------------
 2.5000000000000000 |    16 |        2.5
 2.5000000000000000 |    16 |        2.5
(2 rows)

nathan=# select sqrt(v), scale(sqrt(v)), trim_scale(sqrt(v)) from dec;
       sqrt        | scale | trim_scale
-------------------+-------+------------
 2.000000000000000 |    15 |          2
 2.000000000000000 |    15 |          2
(2 rows)
```

Making this change will improve PG compatibility, especially when we
decide to implement the `scale` and `trim_scale` builtin functions.

Conveniently, removing this also improves performance, as these operations
now perform less work.

```
name                 old time/op    new time/op    delta
GDA/exp-10             20.6ms ± 0%    16.2ms ± 1%  -21.21%  (p=0.000 n=10+10)
GDA/log10-10           25.6ms ± 0%    22.7ms ± 0%  -11.57%  (p=0.000 n=10+9)
GDA/ln-10              19.9ms ± 0%    17.6ms ± 0%  -11.35%  (p=0.000 n=10+10)
GDA/divide-10          65.3µs ± 0%    59.4µs ± 0%   -9.03%  (p=0.000 n=9+9)
GDA/squareroot-10      5.31ms ± 0%    5.01ms ± 0%   -5.57%  (p=0.000 n=10+8)
GDA/powersqrt-10       73.9ms ± 0%    71.3ms ± 0%   -3.48%  (p=0.000 n=9+9)
GDA/cuberoot-apd-10     397µs ± 0%     385µs ± 0%   -3.05%  (p=0.000 n=10+10)
GDA/divideint-10       13.4µs ± 0%    13.4µs ± 0%     ~     (p=0.859 n=9+10)

name                 old alloc/op   new alloc/op   delta
GDA/divide-10          10.6kB ± 0%    10.6kB ± 0%     ~     (all equal)
GDA/divideint-10        96.0B ± 0%     96.0B ± 0%     ~     (all equal)
GDA/cuberoot-apd-10     122kB ± 0%     124kB ± 0%   +1.81%  (p=0.000 n=10+10)
GDA/powersqrt-10       6.27MB ± 0%    6.66MB ± 0%   +6.22%  (p=0.000 n=10+10)
GDA/log10-10           10.4MB ± 0%    11.4MB ± 0%  +10.03%  (p=0.000 n=10+10)
GDA/ln-10              7.93MB ± 0%    8.74MB ± 0%  +10.22%  (p=0.000 n=10+10)
GDA/squareroot-10       147kB ± 0%     170kB ± 0%  +15.82%  (p=0.000 n=10+10)
GDA/exp-10             9.56MB ± 0%   11.26MB ± 0%  +17.71%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
GDA/divide-10             213 ± 0%       213 ± 0%     ~     (all equal)
GDA/divideint-10         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
GDA/cuberoot-apd-10     2.43k ± 0%     2.48k ± 0%   +1.81%  (p=0.000 n=10+10)
GDA/powersqrt-10         210k ± 0%      217k ± 0%   +3.53%  (p=0.000 n=10+10)
GDA/squareroot-10       3.93k ± 0%     4.18k ± 0%   +6.36%  (p=0.000 n=10+10)
GDA/log10-10             205k ± 0%      220k ± 0%   +7.46%  (p=0.000 n=8+10)
GDA/ln-10                157k ± 0%      169k ± 0%   +7.67%  (p=0.000 n=10+10)
GDA/exp-10               127k ± 0%      144k ± 0%  +13.27%  (p=0.000 n=10+10)
```