### PR TITLE
apd: remove some allocs from Decimal.setString

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -141,7 +141,7 @@ func (d *Decimal) setString(c *Context, s string) (Condition, error) {
 		return 0, nil
 	}
 
-	var exps []int64
+	exps := make([]int64, 0, 2)
 	if i := strings.IndexByte(s, 'e'); i >= 0 {
 		exp, err := strconv.ParseInt(s[i+1:], 10, 32)
 		if err != nil {


### PR DESCRIPTION
exps contains exactly 0, 1, or 2 elements.
Provide space for 2 elements up front.
This is an easy, broadly positive optimization.
Some of the time/op benchmarks are noisy;
the allocs benchmarks are clearer.

```
name                           old time/op    new time/op    delta
Exp/P5/S-4/D-2-8                  823ns ± 2%     917ns ±23%  +11.34%  (p=0.000 n=19+19)
Exp/P5/S-4/D2-8                   894ns ±18%     876ns ±15%     ~     (p=0.141 n=18+18)
Exp/P5/S-1/D-2-8                 1.60µs ± 1%    1.73µs ±26%   +8.07%  (p=0.000 n=20+19)
Exp/P5/S-1/D2-8                  1.77µs ± 1%    1.96µs ±21%  +11.08%  (p=0.000 n=20+19)
Exp/P5/S2/D-2-8                  3.92µs ± 1%    4.07µs ±10%   +3.93%  (p=0.049 n=20+17)
Exp/P5/S2/D2-8                   4.38µs ± 0%    4.44µs ± 2%   +1.42%  (p=0.000 n=19+19)
Exp/P10/S-4/D-10-8               1.61µs ± 0%    2.01µs ±57%  +24.95%  (p=0.000 n=17+19)
Exp/P10/S-4/D-2-8                1.42µs ± 0%    1.49µs ± 8%   +4.24%  (p=0.000 n=19+17)
Exp/P10/S-4/D2-8                 1.59µs ± 0%    1.62µs ± 5%     ~     (p=0.587 n=18+20)
Exp/P10/S-4/D10-8                1.54µs ± 0%    1.54µs ± 0%   -0.28%  (p=0.000 n=16+18)
Exp/P10/S-1/D-10-8               2.98µs ± 0%    2.97µs ± 0%   -0.17%  (p=0.002 n=20+19)
Exp/P10/S-1/D-2-8                2.81µs ± 0%    2.81µs ± 0%     ~     (p=0.096 n=20+18)
Exp/P10/S-1/D2-8                 2.99µs ± 0%    3.01µs ± 4%     ~     (p=0.231 n=19+19)
Exp/P10/S-1/D10-8                2.90µs ± 0%    2.96µs ± 7%     ~     (p=0.061 n=20+17)
Exp/P10/S2/D-10-8                6.25µs ± 0%    6.58µs ± 9%   +5.22%  (p=0.000 n=18+20)
Exp/P10/S2/D-2-8                 6.55µs ± 1%    6.56µs ± 4%     ~     (p=0.231 n=19+19)
Exp/P10/S2/D2-8                  6.82µs ± 1%    6.83µs ± 1%     ~     (p=0.702 n=18+18)
Exp/P10/S2/D10-8                 6.50µs ± 0%    6.48µs ± 2%   -0.32%  (p=0.001 n=19+17)
Exp/P100/S-4/D-100-8             50.6µs ± 5%    49.9µs ± 3%   -1.49%  (p=0.004 n=18+16)
Exp/P100/S-4/D-10-8              50.1µs ± 3%    48.6µs ± 1%   -3.04%  (p=0.000 n=18+18)
Exp/P100/S-4/D-2-8               50.2µs ± 3%    49.1µs ± 1%   -2.07%  (p=0.000 n=19+20)
Exp/P100/S-4/D2-8                49.1µs ± 2%    47.5µs ± 1%   -3.19%  (p=0.000 n=18+19)
Exp/P100/S-4/D10-8               49.7µs ± 1%    48.6µs ± 1%   -2.17%  (p=0.000 n=19+20)
Exp/P100/S-4/D100-8              51.0µs ± 1%    50.1µs ± 2%   -1.78%  (p=0.000 n=20+20)
Exp/P100/S-1/D-100-8             96.9µs ± 2%    95.5µs ± 1%   -1.47%  (p=0.000 n=19+17)
Exp/P100/S-1/D-10-8              94.4µs ± 2%    92.4µs ± 1%   -2.12%  (p=0.000 n=20+19)
Exp/P100/S-1/D-2-8               95.0µs ± 2%    93.0µs ± 1%   -2.13%  (p=0.000 n=20+16)
Exp/P100/S-1/D2-8                97.7µs ± 1%    96.4µs ± 2%   -1.38%  (p=0.000 n=20+19)
Exp/P100/S-1/D10-8               93.5µs ± 2%    92.3µs ± 1%   -1.32%  (p=0.000 n=20+19)
Exp/P100/S-1/D100-8              94.9µs ± 1%    93.9µs ± 1%   -1.09%  (p=0.000 n=18+19)
Exp/P100/S2/D-100-8               149µs ± 2%     146µs ± 1%   -2.11%  (p=0.000 n=18+18)
Exp/P100/S2/D-10-8                147µs ± 1%     144µs ± 1%   -2.15%  (p=0.000 n=19+19)
Exp/P100/S2/D-2-8                 153µs ± 2%     148µs ± 1%   -3.31%  (p=0.000 n=20+20)
Exp/P100/S2/D2-8                  150µs ± 1%     145µs ± 1%   -3.15%  (p=0.000 n=19+20)
Exp/P100/S2/D10-8                 149µs ± 1%     144µs ± 1%   -3.43%  (p=0.000 n=20+19)
Exp/P100/S2/D100-8                146µs ± 2%     142µs ± 1%   -2.86%  (p=0.000 n=20+20)
Ln/P2/S-100/D2-8                 6.77µs ± 1%    6.69µs ± 1%   -1.22%  (p=0.000 n=19+19)
Ln/P2/S-10/D2-8                  6.30µs ± 0%    6.20µs ± 0%   -1.57%  (p=0.000 n=19+19)
Ln/P2/S-2/D2-8                   5.83µs ± 1%    5.74µs ± 0%   -1.64%  (p=0.000 n=20+18)
Ln/P2/S2/D2-8                    5.62µs ± 1%    5.52µs ± 0%   -1.76%  (p=0.000 n=18+16)
Ln/P2/S10/D2-8                   6.49µs ± 1%    6.35µs ± 0%   -2.16%  (p=0.000 n=20+16)
Ln/P2/S100/D2-8                  6.71µs ± 1%    6.61µs ± 0%   -1.49%  (p=0.000 n=20+18)
Ln/P10/S-100/D2-8                11.3µs ± 1%    11.2µs ± 0%   -1.01%  (p=0.000 n=20+19)
Ln/P10/S-100/D10-8               11.0µs ± 6%    10.8µs ± 0%   -1.51%  (p=0.000 n=17+18)
Ln/P10/S-10/D2-8                 12.5µs ±15%    11.6µs ± 0%   -7.71%  (p=0.000 n=19+17)
Ln/P10/S-10/D10-8                10.6µs ± 1%    10.5µs ± 0%   -1.00%  (p=0.000 n=19+17)
Ln/P10/S-2/D2-8                  11.0µs ± 3%    10.8µs ± 0%   -1.69%  (p=0.000 n=17+20)
Ln/P10/S-2/D10-8                 12.0µs ± 2%    11.6µs ± 0%   -3.50%  (p=0.000 n=17+18)
Ln/P10/S2/D2-8                   10.6µs ± 2%    10.3µs ± 0%   -2.76%  (p=0.000 n=19+20)
Ln/P10/S2/D10-8                  11.2µs ± 3%    10.7µs ± 0%   -4.22%  (p=0.000 n=18+19)
Ln/P10/S10/D2-8                  11.8µs ± 4%    11.3µs ± 0%   -4.22%  (p=0.000 n=19+20)
Ln/P10/S10/D10-8                 10.5µs ± 8%    10.3µs ± 1%   -2.21%  (p=0.000 n=19+18)
Ln/P10/S100/D2-8                 12.2µs ± 1%    12.2µs ± 4%     ~     (p=0.072 n=18+18)
Ln/P10/S100/D10-8                12.2µs ± 1%    12.5µs ± 9%   +2.71%  (p=0.030 n=20+20)
Ln/P100/S-100/D2-8                415µs ± 1%     409µs ± 2%   -1.59%  (p=0.000 n=20+20)
Ln/P100/S-100/D10-8               370µs ± 1%     360µs ± 1%   -2.63%  (p=0.000 n=19+19)
Ln/P100/S-100/D100-8              394µs ± 2%     381µs ± 1%   -3.28%  (p=0.000 n=20+20)
Ln/P100/S-10/D2-8                 399µs ± 1%     386µs ± 1%   -3.28%  (p=0.000 n=20+19)
Ln/P100/S-10/D10-8                384µs ± 1%     372µs ± 1%   -3.02%  (p=0.000 n=18+20)
Ln/P100/S-10/D100-8               399µs ± 1%     387µs ± 1%   -3.06%  (p=0.000 n=19+18)
Ln/P100/S-2/D2-8                  340µs ± 2%     329µs ± 1%   -3.25%  (p=0.000 n=18+20)
Ln/P100/S-2/D10-8                 365µs ± 1%     366µs ±10%   +0.24%  (p=0.042 n=19+18)
Ln/P100/S-2/D100-8                401µs ± 3%     466µs ±23%  +16.32%  (p=0.000 n=19+20)
Ln/P100/S2/D2-8                   347µs ± 2%     371µs ± 8%   +7.14%  (p=0.000 n=20+20)
Ln/P100/S2/D10-8                  344µs ± 2%     362µs ±14%   +5.44%  (p=0.043 n=20+20)
Ln/P100/S2/D100-8                 368µs ± 2%     361µs ± 2%   -1.93%  (p=0.000 n=19+17)
Ln/P100/S10/D2-8                  355µs ± 1%     349µs ± 2%   -1.76%  (p=0.000 n=19+19)
Ln/P100/S10/D10-8                 381µs ± 3%     373µs ± 4%   -1.96%  (p=0.000 n=17+20)
Ln/P100/S10/D100-8                375µs ± 1%     363µs ± 0%   -3.15%  (p=0.000 n=20+15)
Ln/P100/S100/D2-8                 401µs ± 1%     387µs ± 1%   -3.43%  (p=0.000 n=20+20)
Ln/P100/S100/D10-8                354µs ± 1%     344µs ± 1%   -2.79%  (p=0.000 n=20+17)
Ln/P100/S100/D100-8               390µs ± 2%     379µs ± 2%   -2.91%  (p=0.000 n=20+17)
BigIntBinomial-8                  700ns ± 2%     687ns ± 1%   -1.81%  (p=0.000 n=19+18)
BigIntQuoRem-8                    917ns ± 0%     912ns ± 1%   -0.56%  (p=0.000 n=17+20)
BigIntExp-8                      2.72ms ± 0%    2.71ms ± 0%   -0.46%  (p=0.000 n=20+18)
BigIntExp2-8                     2.72ms ± 0%    2.70ms ± 0%   -0.44%  (p=0.000 n=19+19)
BigIntBitset-8                   10.0ns ± 0%     9.9ns ± 1%   -0.47%  (p=0.000 n=19+17)
BigIntBitsetNeg-8                22.9ns ± 0%    22.7ns ± 0%   -0.57%  (p=0.000 n=18+19)
BigIntBitsetOrig-8               50.5ns ± 1%    49.3ns ± 5%   -2.36%  (p=0.000 n=20+20)
BigIntBitsetNegOrig-8            94.7ns ± 1%    92.2ns ± 1%   -2.60%  (p=0.000 n=18+20)
BigIntModInverse-8                628ns ± 2%     600ns ± 2%   -4.50%  (p=0.000 n=20+20)
BigIntSqrt-8                     12.6µs ± 1%    12.6µs ± 5%   +0.08%  (p=0.020 n=20+19)
BigIntDiv/20/10-8                24.1ns ± 0%    24.1ns ± 1%     ~     (p=0.350 n=19+17)
BigIntDiv/40/20-8                24.1ns ± 0%    24.0ns ± 0%   -0.38%  (p=0.000 n=20+18)
BigIntDiv/100/50-8               33.3ns ± 0%    33.2ns ± 1%   -0.34%  (p=0.000 n=19+18)
BigIntDiv/200/100-8               118ns ± 0%     117ns ± 0%   -0.45%  (p=0.000 n=19+18)
BigIntDiv/400/200-8               136ns ± 0%     135ns ± 0%   -0.45%  (p=0.000 n=18+19)
BigIntDiv/1000/500-8              254ns ± 0%     253ns ± 0%   -0.41%  (p=0.000 n=17+19)
BigIntDiv/2000/1000-8             558ns ±20%     522ns ± 1%   -6.52%  (p=0.000 n=18+19)
BigIntDiv/20000/10000-8          16.9µs ± 1%    16.7µs ± 0%   -1.14%  (p=0.000 n=18+18)
BigIntDiv/200000/100000-8         621µs ± 0%     619µs ± 1%   -0.32%  (p=0.000 n=19+20)
BigIntDiv/2000000/1000000-8      25.5ms ± 1%    25.3ms ± 0%   -0.65%  (p=0.000 n=17+18)
BigIntDiv/20000000/10000000-8     963ms ± 1%     962ms ± 3%   -0.02%  (p=0.005 n=16+18)
GDA/abs-8                        4.06µs ± 2%    4.02µs ± 1%   -0.83%  (p=0.000 n=19+19)
GDA/add-8                         486µs ± 1%     480µs ± 2%   -1.30%  (p=0.000 n=19+20)
GDA/base-8                       84.8µs ± 1%    84.3µs ± 1%   -0.54%  (p=0.000 n=20+18)
GDA/compare-8                    23.7µs ± 1%    23.6µs ± 1%   -0.67%  (p=0.001 n=20+18)
GDA/comparetotal-8               22.7µs ± 2%    22.8µs ± 1%     ~     (p=0.077 n=20+20)
GDA/divide-8                     50.1µs ± 1%    49.4µs ± 1%   -1.33%  (p=0.000 n=20+20)
GDA/divideint-8                  12.4µs ± 5%    12.2µs ± 2%   -2.10%  (p=0.000 n=18+20)
GDA/exp-8                        12.4ms ± 6%    12.0ms ± 1%   -2.89%  (p=0.000 n=19+20)
GDA/ln-8                         13.2ms ± 2%    13.0ms ± 1%   -1.27%  (p=0.000 n=18+19)
GDA/log10-8                      17.8ms ± 3%    16.6ms ± 2%   -6.85%  (p=0.000 n=15+19)
GDA/minus-8                      5.72µs ± 3%    5.56µs ± 1%   -2.89%  (p=0.000 n=18+18)
GDA/multiply-8                   47.0µs ± 8%    44.4µs ± 1%   -5.55%  (p=0.000 n=18+19)
GDA/plus-8                       31.7µs ± 2%    31.0µs ± 1%   -2.37%  (p=0.000 n=17+19)
GDA/power-8                      37.1ms ± 2%    36.0ms ± 1%   -2.81%  (p=0.000 n=20+20)
GDA/powersqrt-8                  53.6ms ± 1%    52.8ms ± 0%   -1.40%  (p=0.000 n=18+19)
GDA/quantize-8                   62.6µs ± 1%    62.2µs ± 1%   -0.64%  (p=0.000 n=19+18)
GDA/randoms-8                    1.03ms ± 0%    1.03ms ± 1%   -0.41%  (p=0.000 n=19+19)
GDA/reduce-8                     9.08µs ± 1%    9.01µs ± 1%   -0.85%  (p=0.000 n=17+20)
GDA/remainder-8                  24.5µs ± 2%    24.3µs ± 1%   -0.64%  (p=0.012 n=19+20)
GDA/rounding-8                    135µs ± 1%     134µs ± 0%   -1.15%  (p=0.000 n=19+20)
GDA/squareroot-8                 3.98ms ± 0%    3.94ms ± 0%   -0.95%  (p=0.000 n=19+20)
GDA/subtract-8                   73.2µs ± 1%    72.4µs ± 1%   -1.11%  (p=0.000 n=17+17)
GDA/tointegral-8                 14.7µs ± 2%    14.6µs ± 3%   -0.67%  (p=0.029 n=18+18)
GDA/tointegralx-8                15.1µs ± 2%    15.4µs ± 5%   +1.49%  (p=0.044 n=18+20)
GDA/cuberoot-apd-8                323µs ± 2%     327µs ± 1%   +1.23%  (p=0.000 n=19+20)
NumDigitsLookup-8                7.84µs ± 1%    7.96µs ± 4%     ~     (p=0.081 n=16+20)
NumDigitsFull-8                  2.15ms ± 1%    2.12ms ± 1%   -1.43%  (p=0.000 n=19+19)

name                           old alloc/op   new alloc/op   delta
Exp/P5/S-4/D-2-8                   152B ± 0%      152B ± 0%     ~     (all equal)
Exp/P5/S-4/D2-8                    152B ± 0%      152B ± 0%     ~     (all equal)
Exp/P5/S-1/D-2-8                   112B ± 0%      112B ± 0%     ~     (all equal)
Exp/P5/S-1/D2-8                    112B ± 0%      112B ± 0%     ~     (all equal)
Exp/P5/S2/D-2-8                    112B ± 0%      112B ± 0%     ~     (all equal)
Exp/P5/S2/D2-8                     112B ± 0%      112B ± 0%     ~     (all equal)
Exp/P10/S-4/D-10-8                 224B ± 0%      224B ± 0%     ~     (all equal)
Exp/P10/S-4/D-2-8                  168B ± 0%      168B ± 0%     ~     (all equal)
Exp/P10/S-4/D2-8                   168B ± 0%      168B ± 0%     ~     (all equal)
Exp/P10/S-4/D10-8                  224B ± 0%      224B ± 0%     ~     (all equal)
Exp/P10/S-1/D-10-8                 224B ± 0%      224B ± 0%     ~     (all equal)
Exp/P10/S-1/D-2-8                  168B ± 0%      168B ± 0%     ~     (all equal)
Exp/P10/S-1/D2-8                   168B ± 0%      168B ± 0%     ~     (all equal)
Exp/P10/S-1/D10-8                  224B ± 0%      224B ± 0%     ~     (all equal)
Exp/P10/S2/D-10-8                  224B ± 0%      224B ± 0%     ~     (all equal)
Exp/P10/S2/D-2-8                   168B ± 0%      168B ± 0%     ~     (all equal)
Exp/P10/S2/D2-8                    168B ± 0%      168B ± 0%     ~     (all equal)
Exp/P10/S2/D10-8                   224B ± 0%      224B ± 0%     ~     (all equal)
Exp/P100/S-4/D-100-8             51.7kB ± 0%    51.7kB ± 0%   -0.00%  (p=0.000 n=18+19)
Exp/P100/S-4/D-10-8              51.0kB ± 0%    51.0kB ± 0%   -0.00%  (p=0.004 n=19+20)
Exp/P100/S-4/D-2-8               52.0kB ± 0%    52.0kB ± 0%     ~     (p=0.759 n=20+19)
Exp/P100/S-4/D2-8                47.2kB ± 0%    47.2kB ± 0%     ~     (p=0.115 n=19+20)
Exp/P100/S-4/D10-8               48.5kB ± 0%    48.5kB ± 0%     ~     (p=0.383 n=20+20)
Exp/P100/S-4/D100-8              49.6kB ± 0%    49.6kB ± 0%     ~     (p=1.000 n=20+20)
Exp/P100/S-1/D-100-8              101kB ± 0%     101kB ± 0%     ~     (p=0.203 n=20+20)
Exp/P100/S-1/D-10-8              98.0kB ± 0%    98.0kB ± 0%     ~     (p=0.115 n=20+20)
Exp/P100/S-1/D-2-8               99.3kB ± 0%    99.3kB ± 0%     ~     (p=0.605 n=20+20)
Exp/P100/S-1/D2-8                96.0kB ± 0%    96.0kB ± 0%     ~     (p=0.059 n=18+20)
Exp/P100/S-1/D10-8               92.0kB ± 0%    92.0kB ± 0%     ~     (p=0.498 n=20+20)
Exp/P100/S-1/D100-8              93.5kB ± 0%    93.5kB ± 0%   -0.01%  (p=0.048 n=20+20)
Exp/P100/S2/D-100-8               147kB ± 0%     147kB ± 0%     ~     (p=0.490 n=20+20)
Exp/P100/S2/D-10-8                145kB ± 0%     145kB ± 0%     ~     (p=0.606 n=20+20)
Exp/P100/S2/D-2-8                 150kB ± 0%     150kB ± 0%     ~     (p=0.917 n=20+19)
Exp/P100/S2/D2-8                  138kB ± 0%     138kB ± 0%     ~     (p=0.784 n=20+20)
Exp/P100/S2/D10-8                 138kB ± 0%     138kB ± 0%   -0.01%  (p=0.047 n=20+20)
Exp/P100/S2/D100-8                134kB ± 0%     134kB ± 0%     ~     (p=0.525 n=20+20)
Ln/P2/S-100/D2-8                 1.21kB ± 0%    1.18kB ± 0%   -2.39%  (p=0.000 n=20+20)
Ln/P2/S-10/D2-8                    644B ± 0%      614B ± 0%   -4.66%  (p=0.000 n=20+20)
Ln/P2/S-2/D2-8                     606B ± 0%      578B ± 0%   -4.69%  (p=0.000 n=20+20)
Ln/P2/S2/D2-8                      581B ± 0%      554B ± 0%   -4.65%  (p=0.000 n=20+19)
Ln/P2/S10/D2-8                     645B ± 0%      615B ± 0%   -4.65%  (p=0.000 n=20+20)
Ln/P2/S100/D2-8                  1.21kB ± 0%    1.18kB ± 0%   -2.40%  (p=0.000 n=20+20)
Ln/P10/S-100/D2-8                1.35kB ± 0%    1.32kB ± 0%   -2.00%  (p=0.000 n=20+20)
Ln/P10/S-100/D10-8               1.39kB ± 0%    1.37kB ± 0%   -1.37%  (p=0.000 n=20+20)
Ln/P10/S-10/D2-8                   825B ± 0%      794B ± 0%   -3.76%  (p=0.000 n=20+20)
Ln/P10/S-10/D10-8                  863B ± 0%      844B ± 0%   -2.20%  (p=0.000 n=20+20)
Ln/P10/S-2/D2-8                    777B ± 0%      748B ± 0%   -3.73%  (p=0.000 n=20+20)
Ln/P10/S-2/D10-8                   837B ± 0%      816B ± 0%   -2.51%  (p=0.000 n=20+20)
Ln/P10/S2/D2-8                     780B ± 0%      753B ± 0%   -3.46%  (p=0.000 n=20+20)
Ln/P10/S2/D10-8                    839B ± 0%      818B ± 0%   -2.50%  (p=0.000 n=20+20)
Ln/P10/S10/D2-8                    818B ± 0%      788B ± 0%   -3.67%  (p=0.000 n=20+20)
Ln/P10/S10/D10-8                   789B ± 0%      770B ± 0%   -2.41%  (p=0.000 n=20+20)
Ln/P10/S100/D2-8                 1.43kB ± 0%    1.40kB ± 0%   -2.16%  (p=0.000 n=20+20)
Ln/P10/S100/D10-8                1.48kB ± 0%    1.45kB ± 0%   -1.49%  (p=0.000 n=19+20)
Ln/P100/S-100/D2-8                407kB ± 0%     407kB ± 0%     ~     (p=0.125 n=19+20)
Ln/P100/S-100/D10-8               363kB ± 0%     363kB ± 0%   -0.03%  (p=0.015 n=20+19)
Ln/P100/S-100/D100-8              384kB ± 0%     383kB ± 0%   -0.03%  (p=0.035 n=20+16)
Ln/P100/S-10/D2-8                 391kB ± 0%     391kB ± 0%   +0.06%  (p=0.000 n=16+20)
Ln/P100/S-10/D10-8                374kB ± 0%     374kB ± 0%   +0.07%  (p=0.000 n=17+18)
Ln/P100/S-10/D100-8               387kB ± 0%     386kB ± 0%   -0.09%  (p=0.000 n=20+20)
Ln/P100/S-2/D2-8                  330kB ± 0%     330kB ± 0%   -0.08%  (p=0.012 n=20+20)
Ln/P100/S-2/D10-8                 357kB ± 0%     357kB ± 0%     ~     (p=0.941 n=20+20)
Ln/P100/S-2/D100-8                390kB ± 0%     390kB ± 0%     ~     (p=0.457 n=20+20)
Ln/P100/S2/D2-8                   343kB ± 0%     343kB ± 0%     ~     (p=0.920 n=20+20)
Ln/P100/S2/D10-8                  336kB ± 0%     336kB ± 0%     ~     (p=0.774 n=20+20)
Ln/P100/S2/D100-8                 358kB ± 0%     359kB ± 0%     ~     (p=0.324 n=20+20)
Ln/P100/S10/D2-8                  348kB ± 0%     348kB ± 0%     ~     (p=0.650 n=15+19)
Ln/P100/S10/D10-8                 372kB ± 0%     372kB ± 0%     ~     (p=0.229 n=20+20)
Ln/P100/S10/D100-8                365kB ± 0%     365kB ± 0%   +0.16%  (p=0.000 n=20+20)
Ln/P100/S100/D2-8                 390kB ± 0%     389kB ± 0%   -0.04%  (p=0.012 n=19+20)
Ln/P100/S100/D10-8                351kB ± 0%     350kB ± 0%   -0.20%  (p=0.001 n=20+20)
Ln/P100/S100/D100-8               384kB ± 0%     384kB ± 0%     ~     (p=0.654 n=20+20)
BigIntBinomial-8                 1.02kB ± 0%    1.02kB ± 0%     ~     (all equal)
BigIntQuoRem-8                    0.00B          0.00B          ~     (all equal)
BigIntExp-8                      11.1kB ± 0%    11.1kB ± 0%     ~     (p=0.979 n=20+20)
BigIntExp2-8                     11.3kB ± 0%    11.3kB ± 0%     ~     (p=0.083 n=20+17)
BigIntBitset-8                    0.00B          0.00B          ~     (all equal)
BigIntBitsetNeg-8                 0.00B          0.00B          ~     (all equal)
BigIntBitsetOrig-8                71.0B ± 0%     71.0B ± 0%     ~     (all equal)
BigIntBitsetNegOrig-8              183B ± 0%      183B ± 0%     ~     (all equal)
BigIntModInverse-8               1.28kB ± 0%    1.28kB ± 0%     ~     (all equal)
BigIntSqrt-8                     5.54kB ± 0%    5.54kB ± 0%     ~     (all equal)
BigIntDiv/20/10-8                 0.00B          0.00B          ~     (all equal)
BigIntDiv/40/20-8                 0.00B          0.00B          ~     (all equal)
BigIntDiv/100/50-8                0.00B          0.00B          ~     (all equal)
BigIntDiv/200/100-8               0.00B          0.00B          ~     (all equal)
BigIntDiv/400/200-8               0.00B          0.00B          ~     (all equal)
BigIntDiv/1000/500-8              0.00B          0.00B          ~     (all equal)
BigIntDiv/2000/1000-8             0.00B          0.00B          ~     (all equal)
BigIntDiv/20000/10000-8            129B ± 0%      129B ± 0%     ~     (all equal)
BigIntDiv/200000/100000-8          804B ± 0%      713B ±48%  -11.34%  (p=0.000 n=16+20)
BigIntDiv/2000000/1000000-8       228kB ±58%     301kB ±91%     ~     (p=0.106 n=16+20)
BigIntDiv/20000000/10000000-8    18.0MB ± 0%     9.3MB ±40%  -48.45%  (p=0.000 n=13+19)
GDA/abs-8                         0.00B          0.00B          ~     (all equal)
GDA/add-8                         459kB ± 0%     459kB ± 0%     ~     (p=0.147 n=20+20)
GDA/base-8                       26.2kB ± 0%    26.2kB ± 0%     ~     (all equal)
GDA/compare-8                     0.00B          0.00B          ~     (all equal)
GDA/comparetotal-8                0.00B          0.00B          ~     (all equal)
GDA/divide-8                     10.6kB ± 0%    10.6kB ± 0%     ~     (all equal)
GDA/divideint-8                   96.0B ± 0%     96.0B ± 0%     ~     (all equal)
GDA/exp-8                        11.2MB ± 0%    11.2MB ± 0%     ~     (p=0.947 n=20+20)
GDA/ln-8                         8.73MB ± 0%    8.73MB ± 0%   -0.07%  (p=0.000 n=19+20)
GDA/log10-8                      11.4MB ± 0%    11.4MB ± 0%   -0.06%  (p=0.000 n=19+20)
GDA/minus-8                       0.00B          0.00B          ~     (all equal)
GDA/multiply-8                   15.7kB ± 0%    15.7kB ± 0%     ~     (all equal)
GDA/plus-8                       41.0kB ± 0%    41.0kB ± 0%     ~     (all equal)
GDA/power-8                      24.1MB ± 0%    24.1MB ± 0%   -0.04%  (p=0.000 n=20+20)
GDA/powersqrt-8                  6.65MB ± 0%    6.58MB ± 0%   -1.17%  (p=0.000 n=20+19)
GDA/quantize-8                   9.20kB ± 0%    9.20kB ± 0%     ~     (p=1.000 n=20+20)
GDA/randoms-8                    48.5kB ± 0%    48.5kB ± 0%     ~     (all equal)
GDA/reduce-8                      0.00B          0.00B          ~     (all equal)
GDA/remainder-8                   96.0B ± 0%     96.0B ± 0%     ~     (all equal)
GDA/rounding-8                   3.07kB ± 0%    3.07kB ± 0%     ~     (all equal)
GDA/squareroot-8                  170kB ± 0%     170kB ± 0%     ~     (p=0.607 n=20+20)
GDA/subtract-8                   35.2kB ± 0%    35.2kB ± 0%     ~     (p=0.063 n=20+20)
GDA/tointegral-8                 6.58kB ± 0%    6.58kB ± 0%     ~     (all equal)
GDA/tointegralx-8                6.58kB ± 0%    6.58kB ± 0%     ~     (all equal)
GDA/cuberoot-apd-8                124kB ± 0%     124kB ± 0%   -0.00%  (p=0.000 n=20+20)
NumDigitsLookup-8                 0.00B          0.00B          ~     (all equal)
NumDigitsFull-8                  3.13MB ± 0%    3.13MB ± 0%     ~     (p=0.564 n=20+19)

name                           old allocs/op  new allocs/op  delta
Exp/P5/S-4/D-2-8                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P5/S-4/D2-8                    12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P5/S-1/D-2-8                   11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Exp/P5/S-1/D2-8                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Exp/P5/S2/D-2-8                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Exp/P5/S2/D2-8                     11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Exp/P10/S-4/D-10-8                 13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Exp/P10/S-4/D-2-8                  12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P10/S-4/D2-8                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P10/S-4/D10-8                  13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Exp/P10/S-1/D-10-8                 13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Exp/P10/S-1/D-2-8                  12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P10/S-1/D2-8                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P10/S-1/D10-8                  13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Exp/P10/S2/D-10-8                  13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Exp/P10/S2/D-2-8                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P10/S2/D2-8                    12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Exp/P10/S2/D10-8                   13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Exp/P100/S-4/D-100-8                692 ± 0%       692 ± 0%     ~     (all equal)
Exp/P100/S-4/D-10-8                 690 ± 0%       690 ± 0%     ~     (all equal)
Exp/P100/S-4/D-2-8                  701 ± 0%       701 ± 0%     ~     (all equal)
Exp/P100/S-4/D2-8                   652 ± 0%       652 ± 0%     ~     (all equal)
Exp/P100/S-4/D10-8                  675 ± 0%       675 ± 0%     ~     (all equal)
Exp/P100/S-4/D100-8                 684 ± 0%       684 ± 0%     ~     (all equal)
Exp/P100/S-1/D-100-8              1.35k ± 0%     1.35k ± 0%     ~     (all equal)
Exp/P100/S-1/D-10-8               1.32k ± 0%     1.32k ± 0%     ~     (all equal)
Exp/P100/S-1/D-2-8                1.33k ± 0%     1.33k ± 0%     ~     (all equal)
Exp/P100/S-1/D2-8                 1.33k ± 0%     1.33k ± 0%     ~     (all equal)
Exp/P100/S-1/D10-8                1.28k ± 0%     1.28k ± 0%     ~     (all equal)
Exp/P100/S-1/D100-8               1.29k ± 0%     1.29k ± 0%     ~     (all equal)
Exp/P100/S2/D-100-8               2.00k ± 0%     2.00k ± 0%     ~     (p=0.741 n=20+20)
Exp/P100/S2/D-10-8                1.98k ± 0%     1.98k ± 0%   -0.01%  (p=0.023 n=16+20)
Exp/P100/S2/D-2-8                 2.05k ± 0%     2.05k ± 0%     ~     (all equal)
Exp/P100/S2/D2-8                  1.94k ± 0%     1.94k ± 0%     ~     (p=0.731 n=20+20)
Exp/P100/S2/D10-8                 1.95k ± 0%     1.95k ± 0%     ~     (all equal)
Exp/P100/S2/D100-8                1.89k ± 0%     1.89k ± 0%     ~     (p=0.320 n=20+20)
Ln/P2/S-100/D2-8                   44.0 ± 0%      42.0 ± 0%   -4.55%  (p=0.000 n=20+20)
Ln/P2/S-10/D2-8                    36.0 ± 0%      34.0 ± 0%   -5.56%  (p=0.000 n=20+20)
Ln/P2/S-2/D2-8                     34.0 ± 0%      32.0 ± 0%   -5.88%  (p=0.000 n=20+20)
Ln/P2/S2/D2-8                      32.0 ± 0%      30.0 ± 0%   -6.25%  (p=0.000 n=20+20)
Ln/P2/S10/D2-8                     36.0 ± 0%      34.0 ± 0%   -5.56%  (p=0.000 n=20+20)
Ln/P2/S100/D2-8                    44.0 ± 0%      42.0 ± 0%   -4.55%  (p=0.000 n=20+20)
Ln/P10/S-100/D2-8                  45.0 ± 0%      44.0 ± 0%   -2.22%  (p=0.000 n=20+20)
Ln/P10/S-100/D10-8                 44.0 ± 0%      43.0 ± 0%   -2.27%  (p=0.000 n=20+20)
Ln/P10/S-10/D2-8                   39.0 ± 0%      37.0 ± 0%   -5.13%  (p=0.000 n=20+20)
Ln/P10/S-10/D10-8                  36.0 ± 0%      35.0 ± 0%   -2.78%  (p=0.000 n=20+20)
Ln/P10/S-2/D2-8                    37.0 ± 0%      35.0 ± 0%   -5.41%  (p=0.000 n=20+20)
Ln/P10/S-2/D10-8                   38.0 ± 0%      36.0 ± 0%   -5.26%  (p=0.000 n=20+20)
Ln/P10/S2/D2-8                     36.0 ± 0%      34.0 ± 0%   -5.56%  (p=0.000 n=20+20)
Ln/P10/S2/D10-8                    38.0 ± 0%      36.0 ± 0%   -5.26%  (p=0.000 n=20+20)
Ln/P10/S10/D2-8                    39.0 ± 0%      37.0 ± 0%   -5.13%  (p=0.000 n=20+20)
Ln/P10/S10/D10-8                   35.0 ± 0%      33.0 ± 0%   -5.71%  (p=0.000 n=20+20)
Ln/P10/S100/D2-8                   49.0 ± 0%      47.0 ± 0%   -4.08%  (p=0.000 n=20+20)
Ln/P10/S100/D10-8                  50.0 ± 0%      48.0 ± 0%   -4.00%  (p=0.000 n=20+20)
Ln/P100/S-100/D2-8                5.55k ± 0%     5.55k ± 0%     ~     (p=0.291 n=19+20)
Ln/P100/S-100/D10-8               4.94k ± 0%     4.94k ± 0%   -0.07%  (p=0.002 n=20+20)
Ln/P100/S-100/D100-8              5.21k ± 0%     5.21k ± 0%   -0.06%  (p=0.000 n=20+16)
Ln/P100/S-10/D2-8                 5.30k ± 0%     5.31k ± 0%     ~     (p=0.063 n=18+20)
Ln/P100/S-10/D10-8                5.09k ± 0%     5.09k ± 0%   +0.04%  (p=0.000 n=17+17)
Ln/P100/S-10/D100-8               5.27k ± 0%     5.27k ± 0%   -0.12%  (p=0.000 n=20+20)
Ln/P100/S-2/D2-8                  4.51k ± 0%     4.51k ± 0%   -0.11%  (p=0.003 n=20+20)
Ln/P100/S-2/D10-8                 4.86k ± 0%     4.86k ± 0%     ~     (p=0.671 n=20+20)
Ln/P100/S-2/D100-8                5.30k ± 0%     5.29k ± 0%     ~     (p=0.165 n=20+20)
Ln/P100/S2/D2-8                   4.64k ± 0%     4.63k ± 0%     ~     (p=0.096 n=20+20)
Ln/P100/S2/D10-8                  4.59k ± 0%     4.58k ± 0%     ~     (p=0.196 n=20+20)
Ln/P100/S2/D100-8                 4.89k ± 0%     4.89k ± 0%     ~     (p=0.962 n=20+20)
Ln/P100/S10/D2-8                  4.73k ± 0%     4.73k ± 0%   -0.05%  (p=0.000 n=15+15)
Ln/P100/S10/D10-8                 5.07k ± 0%     5.06k ± 0%   -0.07%  (p=0.049 n=20+20)
Ln/P100/S10/D100-8                4.98k ± 0%     4.98k ± 0%   +0.13%  (p=0.000 n=20+20)
Ln/P100/S100/D2-8                 5.31k ± 0%     5.31k ± 0%   -0.08%  (p=0.000 n=19+20)
Ln/P100/S100/D10-8                4.78k ± 0%     4.76k ± 0%   -0.21%  (p=0.000 n=20+19)
Ln/P100/S100/D100-8               5.21k ± 0%     5.21k ± 0%     ~     (p=0.163 n=20+20)
BigIntBinomial-8                   38.0 ± 0%      38.0 ± 0%     ~     (all equal)
BigIntQuoRem-8                     0.00           0.00          ~     (all equal)
BigIntExp-8                        21.0 ± 0%      21.0 ± 0%     ~     (all equal)
BigIntExp2-8                       22.0 ± 0%      22.0 ± 0%     ~     (all equal)
BigIntBitset-8                     0.00           0.00          ~     (all equal)
BigIntBitsetNeg-8                  0.00           0.00          ~     (all equal)
BigIntBitsetOrig-8                 0.00           0.00          ~     (all equal)
BigIntBitsetNegOrig-8              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
BigIntModInverse-8                 11.0 ± 0%      11.0 ± 0%     ~     (all equal)
BigIntSqrt-8                       12.0 ± 0%      12.0 ± 0%     ~     (all equal)
BigIntDiv/20/10-8                  0.00           0.00          ~     (all equal)
BigIntDiv/40/20-8                  0.00           0.00          ~     (all equal)
BigIntDiv/100/50-8                 0.00           0.00          ~     (all equal)
BigIntDiv/200/100-8                0.00           0.00          ~     (all equal)
BigIntDiv/400/200-8                0.00           0.00          ~     (all equal)
BigIntDiv/1000/500-8               0.00           0.00          ~     (all equal)
BigIntDiv/2000/1000-8              0.00           0.00          ~     (all equal)
BigIntDiv/20000/10000-8            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
BigIntDiv/200000/100000-8          1.00 ± 0%      1.00 ± 0%     ~     (all equal)
BigIntDiv/2000000/1000000-8        5.25 ±90%      5.25 ±52%     ~     (p=0.828 n=20+20)
BigIntDiv/20000000/10000000-8      78.0 ± 0%      24.2 ±17%  -68.93%  (p=0.000 n=14+17)
GDA/abs-8                          0.00           0.00          ~     (all equal)
GDA/add-8                         4.21k ± 0%     4.21k ± 0%     ~     (all equal)
GDA/base-8                        2.52k ± 0%     2.52k ± 0%     ~     (all equal)
GDA/compare-8                      0.00           0.00          ~     (all equal)
GDA/comparetotal-8                 0.00           0.00          ~     (all equal)
GDA/divide-8                        213 ± 0%       213 ± 0%     ~     (all equal)
GDA/divideint-8                    2.00 ± 0%      2.00 ± 0%     ~     (all equal)
GDA/exp-8                          144k ± 0%      144k ± 0%     ~     (p=0.909 n=20+20)
GDA/ln-8                           169k ± 0%      169k ± 0%   -0.31%  (p=0.000 n=18+20)
GDA/log10-8                        220k ± 0%      220k ± 0%   -0.28%  (p=0.000 n=19+20)
GDA/minus-8                        0.00           0.00          ~     (all equal)
GDA/multiply-8                      312 ± 0%       312 ± 0%     ~     (all equal)
GDA/plus-8                          260 ± 0%       260 ± 0%     ~     (all equal)
GDA/power-8                        473k ± 0%      472k ± 0%   -0.16%  (p=0.000 n=20+20)
GDA/powersqrt-8                    217k ± 0%      212k ± 0%   -2.27%  (p=0.000 n=20+19)
GDA/quantize-8                     53.0 ± 0%      53.0 ± 0%     ~     (all equal)
GDA/randoms-8                       704 ± 0%       704 ± 0%     ~     (all equal)
GDA/reduce-8                       0.00           0.00          ~     (all equal)
GDA/remainder-8                    2.00 ± 0%      2.00 ± 0%     ~     (all equal)
GDA/rounding-8                     96.0 ± 0%      96.0 ± 0%     ~     (all equal)
GDA/squareroot-8                  4.18k ± 0%     4.18k ± 0%     ~     (all equal)
GDA/subtract-8                      210 ± 0%       210 ± 0%     ~     (all equal)
GDA/tointegral-8                   48.0 ± 0%      48.0 ± 0%     ~     (all equal)
GDA/tointegralx-8                  48.0 ± 0%      48.0 ± 0%     ~     (all equal)
GDA/cuberoot-apd-8                2.48k ± 0%     2.48k ± 0%     ~     (all equal)
NumDigitsLookup-8                  0.00           0.00          ~     (all equal)
NumDigitsFull-8                   23.4k ± 0%     23.4k ± 0%     ~     (p=1.000 n=20+20)
```