### PR TITLE
apd: disable staticcheck on Go 1.16 and earlier

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,8 +59,8 @@ jobs:
         run: go vet -unsafeptr=false ./...
 
       - name: 'Staticcheck'
-        # staticcheck requires go1.14.
-        if: ${{ matrix.arch == 'x64' && matrix.go != '1.13' }}
+        # staticcheck requires go1.17.
+        if: ${{ matrix.arch == 'x64' && matrix.go >= '1.17' }}
         run: |
           go get honnef.co/go/tools/cmd/staticcheck
           staticcheck ./...


### PR DESCRIPTION
See https://github.com/dominikh/go-tools/issues/1251.