### PR TITLE
apd: drop github.com/pkg/errors

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -15,9 +15,9 @@
 package apd
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Condition holds condition flags.
@@ -143,7 +143,7 @@ func (r Condition) String() string {
 		case Clamped:
 			s = "clamped"
 		default:
-			panic(errors.Errorf("unknown condition %d", i))
+			panic(fmt.Errorf("unknown condition %d", i))
 		}
 		names = append(names, s)
 	}

--- a/context.go
+++ b/context.go
@@ -15,9 +15,9 @@
 package apd
 
 import (
+	"errors"
+	"fmt"
 	"math"
-
-	"github.com/pkg/errors"
 )
 
 // Context maintains options for Decimal operations. It can safely be used
@@ -116,7 +116,7 @@ func (c *Context) setAsNaN(d *Decimal, x, y *Decimal) (Condition, error) {
 	} else if y != nil && y.Form == NaN {
 		nan = y
 	} else {
-		return 0, errors.Errorf("no NaN value found; was shouldSetAsNaN called?")
+		return 0, errors.New("no NaN value found; was shouldSetAsNaN called?")
 	}
 	d.Set(nan)
 	var res Condition
@@ -149,7 +149,7 @@ func (c *Context) add(d, x, y *Decimal, subtract bool) (Condition, error) {
 	var tmp BigInt
 	a, b, s, err := upscale(x, y, &tmp)
 	if err != nil {
-		return 0, errors.Wrap(err, "add")
+		return 0, fmt.Errorf("add: %w", err)
 	}
 	d.Negative = xn
 	if xn == yn {
@@ -379,7 +379,7 @@ func (c *Context) QuoInteger(d, x, y *Decimal) (Condition, error) {
 	var tmp BigInt
 	a, b, _, err := upscale(x, y, &tmp)
 	if err != nil {
-		return 0, errors.Wrap(err, "QuoInteger")
+		return 0, fmt.Errorf("QuoInteger: %w", err)
 	}
 	d.Coeff.Quo(a, b)
 	d.Form = Finite
@@ -421,7 +421,7 @@ func (c *Context) Rem(d, x, y *Decimal) (Condition, error) {
 	var tmp1 BigInt
 	a, b, s, err := upscale(x, y, &tmp1)
 	if err != nil {
-		return 0, errors.Wrap(err, "Rem")
+		return 0, fmt.Errorf("Rem: %w", err)
 	}
 	var tmp2 BigInt
 	tmp2.QuoRem(a, b, &d.Coeff)
@@ -858,7 +858,7 @@ func (c *Context) Log10(d, x *Decimal) (Condition, error) {
 	var z Decimal
 	_, err := nc.Ln(&z, x)
 	if err != nil {
-		return 0, errors.Wrap(err, "ln")
+		return 0, fmt.Errorf("ln: %w", err)
 	}
 	nc.Precision = c.Precision
 
@@ -942,7 +942,7 @@ func (c *Context) Exp(d, x *Decimal) (Condition, error) {
 	nc := c.WithPrecision(cp)
 	nc.Rounding = RoundHalfEven
 	if _, err := nc.Quo(&r, x, &k); err != nil {
-		return 0, errors.Wrap(err, "Quo")
+		return 0, fmt.Errorf("Quo: %w", err)
 	}
 	var ra Decimal
 	ra.Abs(&r)
@@ -951,7 +951,7 @@ func (c *Context) Exp(d, x *Decimal) (Condition, error) {
 	// Stage 3
 	rf, err := ra.Float64()
 	if err != nil {
-		return 0, errors.Wrap(err, "r.Float64")
+		return 0, fmt.Errorf("r.Float64: %w", err)
 	}
 	pf := float64(p)
 	nf := math.Ceil((1.435*pf - 1.182) / math.Log10(pf/rf))
@@ -983,11 +983,11 @@ func (c *Context) Exp(d, x *Decimal) (Condition, error) {
 	var tmpE BigInt
 	ki, err := exp10(int64(t), &tmpE)
 	if err != nil {
-		return 0, errors.Wrap(err, "ki")
+		return 0, fmt.Errorf("ki: %w", err)
 	}
 	ires, err := nc.integerPower(d, &sum, ki)
 	if err != nil {
-		return 0, errors.Wrap(err, "integer power")
+		return 0, fmt.Errorf("integer power: %w", err)
 	}
 	res |= ires
 	nc.Precision = c.Precision

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cockroachdb/apd/v3
 
-go 1.13
+go 1.17
 
-require github.com/pkg/errors v0.8.0
+require github.com/lib/pq v1.10.7

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
+github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/loop.go
+++ b/loop.go
@@ -7,9 +7,8 @@
 package apd
 
 import (
+	"fmt"
 	"math"
-
-	"github.com/pkg/errors"
 )
 
 type loop struct {
@@ -79,7 +78,7 @@ func (l *loop) done(z *Decimal) (bool, error) {
 	}
 	l.i++
 	if l.i == l.maxIterations {
-		return false, errors.Errorf(
+		return false, fmt.Errorf(
 			"%s %s: did not converge after %d iterations; prev,last result %s,%s delta %s precision: %d",
 			l.name, l.arg.String(), l.maxIterations, z.String(), l.prevZ.String(), l.delta.String(), l.precision,
 		)

--- a/sql_test.go
+++ b/sql_test.go
@@ -12,6 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build sql
 // +build sql
 
 package apd
@@ -34,8 +35,8 @@ func TestSQL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a, _, err := NewFromString("1234.567e5")
-	if err != nil {
+	var a Decimal
+	if _, _, err = a.SetString("1234.567e5"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("drop table if exists d"); err != nil {
@@ -52,14 +53,14 @@ func TestSQL(t *testing.T) {
 	}
 	var b, c, d Decimal
 	var nd NullDecimal
-	if err := db.QueryRow("select v, v::text, v::int, v::float, v from d").Scan(a, &b, &c, &d, &nd); err != nil {
+	if err := db.QueryRow("select v, v::text, v::int, v::float, v from d").Scan(&a, &b, &c, &d, &nd); err != nil {
 		t.Fatal(err)
 	}
 	want, _, err := NewFromString("123556700")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i, v := range []*Decimal{a, &b, &c, &d, &nd.Decimal} {
+	for i, v := range []*Decimal{&a, &b, &c, &d, &nd.Decimal} {
 		if v.Cmp(want) != 0 {
 			t.Fatalf("%d: unexpected: %s, want: %s", i, v.String(), want.String())
 		}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/apd/issues/123.

Now that the stdlib's "errors" package supports wrapping, use it to eliminate a dependency on "github.com/pkg/errors".

Picks up the "lib/pq" test dependency. Bump `go.mod` to `go 1.17` to allow users of the library to prune this dependency (https://go.dev/ref/mod#graph-pruning).

@mvdan do you mind giving this a look?