### PR TITLE
apd: Improve string conversion efficiency

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -24,11 +24,11 @@ import (
 // runBenches benchmarks a given function on random decimals on combinations of
 // three parameters:
 //
-//   precision:    desired output precision
-//   inScale:      the scale of the input decimal: the absolute value will be between
-//                 10^inScale and 10^(inScale+1)
-//   inNumDigits:  number of digits in the input decimal; if negative the number
-//                 will be negative and the number of digits are the absolute value.
+//	precision:    desired output precision
+//	inScale:      the scale of the input decimal: the absolute value will be between
+//	              10^inScale and 10^(inScale+1)
+//	inNumDigits:  number of digits in the input decimal; if negative the number
+//	              will be negative and the number of digits are the absolute value.
 func runBenches(
 	b *testing.B, precision, inScale, inNumDigits []int, fn func(*testing.B, *Context, *Decimal),
 ) {
@@ -102,4 +102,23 @@ func BenchmarkLn(b *testing.B) {
 			}
 		},
 	)
+}
+
+func BenchmarkDecimalString(b *testing.B) {
+	rng := rand.New(rand.NewSource(461210934723948))
+	corpus := func() []Decimal {
+		res := make([]Decimal, 8192)
+		for i := range res {
+			_, err := res[i].SetFloat64(rng.Float64())
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		return res
+	}()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = corpus[rng.Intn(len(corpus))].String()
+	}
 }


### PR DESCRIPTION
Prefer to use Append and allocate scratch space
to improve speed and efficiency of string conversion:

```
name              old time/op    new time/op    delta
DecimalString-10     147ns ± 1%      56ns ± 4%  -62.14%  (p=0.000
n=10+10)

name              old alloc/op   new alloc/op   delta
DecimalString-10     84.0B ± 0%     39.0B ± 0%  -53.57%  (p=0.000
n=10+10)

name              old allocs/op  new allocs/op  delta
DecimalString-10      5.00 ± 0%      1.00 ± 0%  -80.00%  (p=0.000
n=10+10)
```