### PR TITLE
apd: add go 1.19 testing to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,7 @@ jobs:
           - '1.16'
           - '1.17'
           - '1.18'
+          - '1.19'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This commit adds a test variant for go 1.19.