### PR TITLE
apd: add go 1.20 testing to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,6 +26,7 @@ jobs:
           - '1.17'
           - '1.18'
           - '1.19'
+          - '1.20'
 
     steps:
       - uses: actions/checkout@v2
@@ -61,8 +62,8 @@ jobs:
         run: go vet -unsafeptr=false ./...
 
       - name: 'Staticcheck'
-        # staticcheck requires go1.17.
-        if: ${{ matrix.arch == 'x64' && matrix.go >= '1.17' }}
+        # staticcheck requires go1.19.
+        if: ${{ matrix.arch == 'x64' && matrix.go >= '1.19' }}
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           staticcheck ./...


### PR DESCRIPTION
This commit adds a test variant for go 1.20.