### PR TITLE
apd: fix TestFormatFlags on go 1.23, add go 1.23 to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,7 @@ jobs:
           - '1.20'
           - '1.21'
           - '1.22'
+          - '1.23'
 
     steps:
       - uses: actions/checkout@v2
@@ -62,10 +63,10 @@ jobs:
         run: go vet -unsafeptr=false ./...
 
       - name: 'Staticcheck'
-        # staticcheck requires go1.19.
-        if: ${{ matrix.arch == 'x64' && matrix.go >= '1.19' }}
+        # staticcheck requires go1.22.
+        if: ${{ matrix.arch == 'x64' && matrix.go >= '1.22' }}
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.0
           staticcheck ./...
 
       - name: 'GCAssert'

--- a/bigint_go1.15_test.go
+++ b/bigint_go1.15_test.go
@@ -65,7 +65,7 @@ func TestBigIntFillBytes(t *testing.T) {
 		"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 	} {
 		t.Run(n, func(t *testing.T) {
-			t.Logf(n)
+			t.Log(n)
 			x, ok := new(BigInt).SetString(n, 0)
 			if !ok {
 				panic("invalid test entry")


### PR DESCRIPTION
Fixes #138.

The test was failing due to https://github.com/golang/go/commit/6dfd7a543517db868ef4f31e91fe56aba5bc8ea0. This PR fixes it.

This PR then adds a test variant for go 1.23.