### PR TITLE
apd: prevent NewFromString parsing invalid decimals

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -156,6 +156,11 @@ func (d *Decimal) setString(c *Context, s string) (Condition, error) {
 		exps = append(exps, -exp)
 		s = s[:i] + s[i+1:]
 	}
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("parse mantissa: %s", s)
+		}
+	}
 	if _, ok := d.Coeff.SetString(s, 10); !ok {
 		return 0, fmt.Errorf("parse mantissa: %s", s)
 	}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -964,3 +964,33 @@ func TestJSONEncoding(t *testing.T) {
 		}
 	}
 }
+
+// TestNewFromStringInvalid tests that NewFromString produces
+// an error when parsing an invalid decimal.
+func TestNewFromStringInvalid(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{input: ".-5"},
+		{input: ".+5"},
+		{input: ".-0"},
+		{input: ".+0"},
+		{input: ".-123"},
+		{input: ".+123"},
+		{input: "1.-2"},
+		{input: "1.+2"},
+		{input: ".1-2"},
+		{input: ".1+2"},
+		{input: ".-5e1"},
+		{input: ".+5e1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			d, _, err := NewFromString(tc.input)
+			if err == nil {
+				t.Fatalf("expected error for %q, but parsed as: %s (Negative=%v, Coeff=%s)",
+					tc.input, d.String(), d.Negative, d.Coeff.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes a parsing bug outlined in #144  where sign characters (`+`, `-`) immediately after a decimal point bypass `setString`'s sign validation and are passed to `big.Int.SetString`, which accepts them. This produces corrupt `Decimal` values.

The fix validates that the mantissa contains only ASCII digits (0-9) after the decimal point and exponent have been removed, before it is passed to `big.Int.SetString`.

Related: #120 